### PR TITLE
Remove `deg(...)` from `opw_parameters.yaml` files

### DIFF
--- a/motoman_gp110_support/config/opw_parameters_gp110.yaml
+++ b/motoman_gp110_support/config/opw_parameters_gp110.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.870
     c3:  1.020
     c4:  0.200
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp180_support/config/opw_parameters_gp180.yaml
+++ b/motoman_gp180_support/config/opw_parameters_gp180.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2: 1.150
     c3: 1.225
     c4: 0.225
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp180_support/config/opw_parameters_gp180_120.yaml
+++ b/motoman_gp180_support/config/opw_parameters_gp180_120.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2: 1.150
     c3: 1.590
     c4: 0.225
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp20hl_support/config/opw_parameters_gp20hl.yaml
+++ b/motoman_gp20hl_support/config/opw_parameters_gp20hl.yaml
@@ -23,5 +23,6 @@ opw_kinematics_geometric_parameters:
     c2:  1.150
     c3:  1.812
     c4:  0.100
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp225_support/config/opw_parameters_gp225.yaml
+++ b/motoman_gp225_support/config/opw_parameters_gp225.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2: 1.150
     c3: 1.225
     c4: 0.250
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp25_support/config/opw_parameters_gp25.yaml
+++ b/motoman_gp25_support/config/opw_parameters_gp25.yaml
@@ -23,5 +23,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.760
     c3:  0.795
     c4:  0.100
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp25_support/config/opw_parameters_gp25_12.yaml
+++ b/motoman_gp25_support/config/opw_parameters_gp25_12.yaml
@@ -23,5 +23,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.760
     c3:  1.082
     c4:  0.100
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp25_support/config/opw_parameters_gp25_20.yaml
+++ b/motoman_gp25_support/config/opw_parameters_gp25_20.yaml
@@ -23,5 +23,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.760
     c3:  0.870
     c4:  0.105
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp35l_support/config/opw_parameters_gp35l.yaml
+++ b/motoman_gp35l_support/config/opw_parameters_gp35l.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  1.150
     c3:  1.225
     c4:  0.175
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp4_support/config/opw_parameters_gp4.yaml
+++ b/motoman_gp4_support/config/opw_parameters_gp4.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.260
     c3:  0.290
     c4:  0.072
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp70l_support/config/opw_parameters_gp70l.yaml
+++ b/motoman_gp70l_support/config/opw_parameters_gp70l.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  1.150
     c3:  1.225
     c4:  0.175
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp7_support/config/opw_parameters_gp7.yaml
+++ b/motoman_gp7_support/config/opw_parameters_gp7.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.445
     c3:  0.440
     c4:  0.080
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp8_support/config/opw_parameters_gp8.yaml
+++ b/motoman_gp8_support/config/opw_parameters_gp8.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.345
     c3:  0.340
     c4:  0.080
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_gp8l_support/config/opw_parameters_gp8l.yaml
+++ b/motoman_gp8l_support/config/opw_parameters_gp8l.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.714
     c3:  0.740
     c4:  0.080
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_hc20_support/config/opw_parameters_hc20.yaml
+++ b/motoman_hc20_support/config/opw_parameters_hc20.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.820
     c3:  0.880
     c4:  0.200
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_hc20_support/config/opw_parameters_hc20dtp.yaml
+++ b/motoman_hc20_support/config/opw_parameters_hc20dtp.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.820
     c3:  0.880
     c4:  0.200
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_hc20_support/config/opw_parameters_hc30pl.yaml
+++ b/motoman_hc20_support/config/opw_parameters_hc30pl.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.820
     c3:  0.880
     c4:  0.200
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, -90.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, -1.57079632679, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_mh110_support/config/opw_parameters_mh110.yaml
+++ b/motoman_mh110_support/config/opw_parameters_mh110.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.870
     c3:  1.020
     c4:  0.200
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_mh12_support/config/opw_parameters_mh12.yaml
+++ b/motoman_mh12_support/config/opw_parameters_mh12.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.614
     c3:  0.640
     c4:  0.100
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_mh5_support/config/opw_parameters_mh5.yaml
+++ b/motoman_mh5_support/config/opw_parameters_mh5.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.310
     c3:  0.305
     c4:  0.080
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_mh5_support/config/opw_parameters_mh5l.yaml
+++ b/motoman_mh5_support/config/opw_parameters_mh5l.yaml
@@ -16,5 +16,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.400
     c3:  0.405
     c4:  0.080
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/motoman_mpx1950_support/config/opw_parameters_mpx1950.yaml
+++ b/motoman_mpx1950_support/config/opw_parameters_mpx1950.yaml
@@ -23,5 +23,6 @@ opw_kinematics_geometric_parameters:
     c2:  0.725
     c3:  0.725
     c4:  0.100
+# Joint offsets (in degrees): [0.0, 0.0, -90.0, 0.0, 0.0, 180.0]
 opw_kinematics_joint_offsets: [0.0, 0.0, -1.57079632679, 0.0, 0.0, 3.14159265359]
 opw_kinematics_joint_sign_corrections: [1, 1, -1, -1, -1, -1]


### PR DESCRIPTION
All of the opw parameter files used `deg()` syntax described here https://github.com/JeroenDM/moveit_opw_kinematics_plugin/issues/67#issuecomment-673388173, but that is no longer supported. The relevant values have been changed back to radians