### PR TITLE
Add `flange` and `tool0` for single-arm robots and positioners

### DIFF
--- a/motoman_ar2010_support/urdf/ar2010_macro.xacro
+++ b/motoman_ar2010_support/urdf/ar2010_macro.xacro
@@ -167,5 +167,6 @@
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
+    
   </xacro:macro>
 </robot>

--- a/motoman_es_support/urdf/es165_macro.xacro
+++ b/motoman_es_support/urdf/es165_macro.xacro
@@ -224,6 +224,15 @@
       <child link="${prefix}balancer_rod"/>
     </joint>
     -->
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.450" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
@@ -241,14 +250,5 @@
       <child link="${prefix}tool0"/>
     </joint>
     
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.450" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_es_support/urdf/es200_120_macro.xacro
+++ b/motoman_es_support/urdf/es200_120_macro.xacro
@@ -222,6 +222,15 @@
       <child link="${prefix}balancer_rod"/>
     </joint>
     -->
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base"/>
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.450" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
@@ -239,14 +248,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base"/>
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.450" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp110_support/urdf/gp110_macro.xacro
+++ b/motoman_gp110_support/urdf/gp110_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.540" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp12_support/urdf/gp12_macro.xacro
+++ b/motoman_gp12_support/urdf/gp12_macro.xacro
@@ -140,6 +140,15 @@
         <axis xyz="-1 0 0" />
         <limit lower="-7.9412" upper="7.9412" effort="33.30" velocity="12.2143"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.450" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
@@ -155,16 +164,6 @@
       <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
-    </joint>
-
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.450" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
     </xacro:macro>

--- a/motoman_gp180_support/urdf/gp180_120_macro.xacro
+++ b/motoman_gp180_support/urdf/gp180_120_macro.xacro
@@ -140,6 +140,15 @@
         <axis xyz="-1 0 0" />
         <limit lower="${radians(-360)}" upper="${radians(360)}" effort="926.73" velocity="${radians(265)}"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.650" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange" />
@@ -155,15 +164,6 @@
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />
         <parent link="${prefix}flange" />
         <child link="${prefix}tool0" />
-    </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.650" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
 </xacro:macro>

--- a/motoman_gp20hl_support/urdf/gp20hl_macro.xacro
+++ b/motoman_gp20hl_support/urdf/gp20hl_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.540" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp215_support/urdf/gp215_macro.xacro
+++ b/motoman_gp215_support/urdf/gp215_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.640" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.640" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp225_support/urdf/gp225_macro.xacro
+++ b/motoman_gp225_support/urdf/gp225_macro.xacro
@@ -141,7 +141,6 @@
         <axis xyz="-1 0 0" />
         <limit lower="${radians(-360)}" upper="${radians(360)}" effort="2250.6" velocity="${radians(220)}"/>
     </joint>
-    <!-- end of joint list -->
 
     <!-- balancer -->
     <link name="${prefix}link_1_s_2">
@@ -182,6 +181,7 @@
         <limit lower="${radians(-60)}" upper="${radians(76)}" effort="11522.8" velocity="${radians(97)}"/>
         <mimic joint="${prefix}joint_2_l" multiplier="-0.2366"/>
     </joint>
+    <!-- end of joint list -->
 
     <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
     <link name="${prefix}base" />
@@ -206,5 +206,6 @@
         <parent link="${prefix}flange" />
         <child link="${prefix}tool0" />
     </joint>
+    
 </xacro:macro>
 </robot>

--- a/motoman_gp250_support/urdf/gp250_macro.xacro
+++ b/motoman_gp250_support/urdf/gp250_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.640" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.640" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp25_support/urdf/gp25_12_macro.xacro
+++ b/motoman_gp25_support/urdf/gp25_12_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.505" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -156,14 +164,6 @@
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
-    </joint>
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.505" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
     </xacro:macro>

--- a/motoman_gp25_support/urdf/gp25_20_macro.xacro
+++ b/motoman_gp25_support/urdf/gp25_20_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.505" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,13 +166,6 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.505" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>
 

--- a/motoman_gp25_support/urdf/gp25_macro.xacro
+++ b/motoman_gp25_support/urdf/gp25_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.505" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -156,14 +164,6 @@
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
-    </joint>
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.505" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
     </xacro:macro>

--- a/motoman_gp35l_support/urdf/gp35l_macro.xacro
+++ b/motoman_gp35l_support/urdf/gp35l_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.540" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp4_support/urdf/gp4_macro.xacro
+++ b/motoman_gp4_support/urdf/gp4_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.330" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp50_support/urdf/gp50_macro.xacro
+++ b/motoman_gp50_support/urdf/gp50_macro.xacro
@@ -140,6 +140,15 @@
         <axis xyz="-1 0 0" />
         <limit lower="${radians(-360)}" upper="${radians(360)}" effort="375" velocity="${radians(360)}"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.540" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange" />
@@ -155,15 +164,6 @@
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />
         <parent link="${prefix}flange" />
         <child link="${prefix}tool0" />
-    </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.540" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
   </xacro:macro>

--- a/motoman_gp70l_support/urdf/gp70l_macro.xacro
+++ b/motoman_gp70l_support/urdf/gp70l_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.540" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_gp7_support/urdf/gp7_macro.xacro
+++ b/motoman_gp7_support/urdf/gp7_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.330" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -156,14 +164,6 @@
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
         <parent link="${prefix}flange"/>
         <child link="${prefix}tool0"/>
-    </joint>
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.330" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
     </xacro:macro>

--- a/motoman_gp88_support/urdf/gp88_macro.xacro
+++ b/motoman_gp88_support/urdf/gp88_macro.xacro
@@ -165,5 +165,6 @@
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
+    
   </xacro:macro>
 </robot>

--- a/motoman_gp8_support/urdf/gp8_macro.xacro
+++ b/motoman_gp8_support/urdf/gp8_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.330" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -156,14 +164,6 @@
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
-    </joint>
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.330" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
     </joint>
 
   </xacro:macro>

--- a/motoman_gp8l_support/urdf/gp8l_macro.xacro
+++ b/motoman_gp8l_support/urdf/gp8l_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.450" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.450" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_hc10_support/urdf/hc10_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10_macro.xacro
@@ -140,6 +140,15 @@
       <axis xyz="0 0 1" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="31.36" velocity="${radians(250)}"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.275" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange" />
@@ -156,14 +165,6 @@
         <parent link="${prefix}flange" />
         <child link="${prefix}tool0" />
     </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.275" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
+    
   </xacro:macro>
 </robot>

--- a/motoman_hc10_support/urdf/hc10dt_b10_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10dt_b10_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.275" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.275" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_hc10_support/urdf/hc10dt_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10dt_macro.xacro
@@ -140,6 +140,16 @@
       <axis xyz="0 0 1" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="31.36" velocity="${radians(250)}"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.275" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -155,14 +165,6 @@
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.275" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
+    
   </xacro:macro>
 </robot>

--- a/motoman_hc10_support/urdf/hc10dtp_b00_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10dtp_b00_macro.xacro
@@ -144,6 +144,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.275" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -160,12 +168,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.275" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_hc20_support/urdf/hc20_macro.xacro
+++ b/motoman_hc20_support/urdf/hc20_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.380" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.380" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_hc20_support/urdf/hc20dtp_macro.xacro
+++ b/motoman_hc20_support/urdf/hc20dtp_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.380" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.380" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_hc20_support/urdf/hc30pl_macro.xacro
+++ b/motoman_hc20_support/urdf/hc30pl_macro.xacro
@@ -148,6 +148,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.380" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -164,12 +172,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.380" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_ma2010_support/urdf/ma2010_macro.xacro
+++ b/motoman_ma2010_support/urdf/ma2010_macro.xacro
@@ -140,6 +140,15 @@
       <axis xyz="-1 0 0" />
       <limit lower="-3.6652" upper="3.6652" effort="29.6" velocity="10.6465"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.505" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
@@ -156,14 +165,6 @@
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.505" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
+    
   </xacro:macro>
 </robot>

--- a/motoman_mh110_support/urdf/mh110_macro.xacro
+++ b/motoman_mh110_support/urdf/mh110_macro.xacro
@@ -143,6 +143,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -159,12 +167,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.540" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_mh12_support/urdf/mh12_macro.xacro
+++ b/motoman_mh12_support/urdf/mh12_macro.xacro
@@ -140,7 +140,16 @@
         <axis xyz="-1 0 0" />
         <limit lower="${radians(-360)}" upper="${radians(360)}" effort="14.80" velocity="${radians(610)}"/>
     </joint>
+    <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.450" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+    
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -155,15 +164,6 @@
       <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
-    </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.450" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
     </xacro:macro>

--- a/motoman_mh50_support/urdf/mh50_macro.xacro
+++ b/motoman_mh50_support/urdf/mh50_macro.xacro
@@ -140,6 +140,16 @@
         <axis xyz="-1 0 0" />
         <limit lower="-6.2831" upper="6.2831" effort="333.43" velocity="6.283"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.540" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+    
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -154,15 +164,6 @@
       <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
-    </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.540" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
     </xacro:macro>

--- a/motoman_motomini_support/urdf/motomini_macro.xacro
+++ b/motoman_motomini_support/urdf/motomini_macro.xacro
@@ -140,6 +140,15 @@
     <axis xyz="0 0 1" />
     <limit lower="-6.2831" upper="6.2831" effort="0.07" velocity="10.4719"/>
   </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.103" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
 
   <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
@@ -156,15 +165,6 @@
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
-  <!-- end of joint list -->
-
-  <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-  <link name="${prefix}base" />
-  <joint name="${prefix}base_link-base" type="fixed">
-    <origin xyz="0 0 0.103" rpy="0 0 0"/>
-    <parent link="${prefix}base_link"/>
-    <child link="${prefix}base"/>
-  </joint>
 
   </xacro:macro>
 </robot>

--- a/motoman_motopos_d500_support/urdf/motopos_d500_macro.xacro
+++ b/motoman_motopos_d500_support/urdf/motopos_d500_macro.xacro
@@ -70,7 +70,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
 
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_2-flange" type="fixed">
@@ -79,11 +79,13 @@
       <child link="${prefix}flange"/>
     </joint>
 
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.14159265359"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
+
   </xacro:macro>
 </robot>

--- a/motoman_motopos_mh1655_support/urdf/motopos_mh1655_macro.xacro
+++ b/motoman_motopos_mh1655_support/urdf/motopos_mh1655_macro.xacro
@@ -84,5 +84,6 @@
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
+    
   </xacro:macro>
 </robot>

--- a/motoman_mpx1950_support/urdf/mpx1950_macro.xacro
+++ b/motoman_mpx1950_support/urdf/mpx1950_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.500" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -158,12 +166,5 @@
       <child link="${prefix}tool0"/>
     </joint>
 
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.500" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_ms210_support/urdf/ms210_macro.xacro
+++ b/motoman_ms210_support/urdf/ms210_macro.xacro
@@ -154,6 +154,15 @@
     <axis xyz="-1 0 0" />
     <limit lower="${radians(-210)}" upper="${radians(210)}" effort="1800.5" velocity="${radians(220)}" />
   </joint>
+  <!-- end of joint list -->
+
+  <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+  <link name="${prefix}base" />
+  <joint name="${prefix}base_link-base" type="fixed">
+    <origin xyz="0 0 0.650" rpy="0 0 0"/>
+    <parent link="${prefix}base_link"/>
+    <child link="${prefix}base"/>
+  </joint>
 
   <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
   <link name="${prefix}flange"/>
@@ -170,14 +179,6 @@
     <parent link="${prefix}flange"/>
     <child link="${prefix}tool0"/>
   </joint>
-  <!-- end of joint list -->
-
-  <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-  <link name="${prefix}base" />
-  <joint name="${prefix}base_link-base" type="fixed">
-    <origin xyz="0 0 0.650" rpy="0 0 0"/>
-    <parent link="${prefix}base_link"/>
-    <child link="${prefix}base"/>
-  </joint>
+  
 </xacro:macro>
 </robot>

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -279,6 +279,16 @@
             <axis xyz="0 0 -1" />
             <limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
         </joint>
+        <!-- end of joint list -->
+
+        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.360" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+        
         <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}joint_t-flange" type="fixed">
@@ -294,14 +304,6 @@
             <parent link="${prefix}flange"/>
             <child link="${prefix}tool0"/>
         </joint>
-        <!-- end of joint list -->
 
-        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-        <link name="${prefix}base" />
-        <joint name="${prefix}base_link-base" type="fixed">
-            <origin xyz="0 0 0.360" rpy="0 0 0"/>
-            <parent link="${prefix}base_link"/>
-            <child link="${prefix}base"/>
-        </joint>
     </xacro:macro>
 </robot>

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -179,6 +179,15 @@
             <axis xyz="0 0 -1" />
             <limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.9813" />
         </joint>
+        <!-- end of joint list -->
+
+        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.360" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
 
         <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
         <link name="${prefix}flange"/>
@@ -195,14 +204,6 @@
             <parent link="${prefix}flange"/>
             <child link="${prefix}tool0"/>
         </joint>
-        <!-- end of joint list -->
-
-        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-        <link name="${prefix}base" />
-        <joint name="${prefix}base_link-base" type="fixed">
-            <origin xyz="0 0 0.360" rpy="0 0 0"/>
-            <parent link="${prefix}base_link"/>
-            <child link="${prefix}base"/>
-        </joint>
+        
     </xacro:macro>
 </robot>

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -179,7 +179,16 @@
             <axis xyz="0 0 -1" />
             <limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
         </joint>
+        <!-- end of joint list -->
 
+        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+        <link name="${prefix}base" />
+        <joint name="${prefix}base_link-base" type="fixed">
+            <origin xyz="0 0 0.410" rpy="0 0 0"/>
+            <parent link="${prefix}base_link"/>
+            <child link="${prefix}base"/>
+        </joint>
+        
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}link_t-flange" type="fixed">
@@ -195,14 +204,6 @@
             <parent link="${prefix}flange"/>
             <child link="${prefix}tool0"/>
         </joint>
-        <!-- end of joint list -->
 
-        <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-        <link name="${prefix}base" />
-        <joint name="${prefix}base_link-base" type="fixed">
-            <origin xyz="0 0 0.410" rpy="0 0 0"/>
-            <parent link="${prefix}base_link"/>
-            <child link="${prefix}base"/>
-        </joint>
     </xacro:macro>
 </robot>

--- a/motoman_sia30d_support/urdf/sia30d_macro.xacro
+++ b/motoman_sia30d_support/urdf/sia30d_macro.xacro
@@ -160,6 +160,15 @@
       <axis xyz="0 0 -1" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="77" velocity="${radians(200)}"/>
     </joint>
+    <!-- end of joint list -->
+
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.598" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
 
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
@@ -175,15 +184,6 @@
         <origin xyz="0 0 0 " rpy="0 ${radians(-90)} ${radians(180)}"/>
         <parent link="${prefix}flange"/>
         <child link="${prefix}tool0"/>
-    </joint>
-    <!-- end of joint list -->
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.598" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
     </joint>
   </xacro:macro>
 </robot>

--- a/motoman_sia50_support/urdf/sia50_macro.xacro
+++ b/motoman_sia50_support/urdf/sia50_macro.xacro
@@ -179,7 +179,16 @@
       <axis xyz="-1 0 0" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="255.76" velocity="${radians(200)}" />
     </joint>
+    <!-- end of joint list -->
 
+    <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.540" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+    
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_t-flange" type="fixed">
@@ -195,14 +204,6 @@
         <parent link="${prefix}flange"/>
         <child link="${prefix}tool0"/>
     </joint>
-    <!-- end of joint list -->
 
-    <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.540" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
   </xacro:macro>
 </robot>

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -182,7 +182,17 @@
     <axis xyz="-1 0 0" />
     <limit lower="${-90*deg}" upper="${90*deg}" effort="0" velocity="${350*deg}" />
   </joint>
+  <!-- end of joint list -->
   
+  <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+      <origin xyz="0 0 0.310" rpy="0 0 0"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}base"/>
+    </joint>
+    </xacro:macro>
+
   <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
   <link name="${prefix}flange"/>
   <joint name="${prefix}joint_t-flange" type="fixed">
@@ -199,13 +209,5 @@
     <child link="${prefix}tool0"/>
   </joint>
 
-    <!-- ROS base_link (via base_link) to Motoman Robot (not Base) Frame transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-      <origin xyz="0 0 0.310" rpy="0 0 0"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-    </xacro:macro>
 </robot>
 

--- a/motoman_up50n_support/urdf/up50n_35_macro.xacro
+++ b/motoman_up50n_support/urdf/up50n_35_macro.xacro
@@ -142,6 +142,14 @@
     </joint>
     <!-- end of joint list -->
 
+    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
+    <link name="${prefix}base" />
+    <joint name="${prefix}base_link-base" type="fixed">
+        <origin xyz="0 0 0.540" rpy="0 0 0"/>
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}base"/>
+    </joint>
+
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
@@ -156,14 +164,6 @@
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
         <parent link="${prefix}flange"/>
         <child link="${prefix}tool0"/>
-    </joint>
-
-    <!-- ROS base_link to Robot Manufacturer World Coordinates transform -->
-    <link name="${prefix}base" />
-    <joint name="${prefix}base_link-base" type="fixed">
-        <origin xyz="0 0 0.540" rpy="0 0 0"/>
-        <parent link="${prefix}base_link"/>
-        <child link="${prefix}base"/>
     </joint>
 
   </xacro:macro>


### PR DESCRIPTION
Addresses #4

Added `flange` and `tool0` for all single-arm robots and positioners. I checked all new `flange` and `tool0` to make sure they follow the standards, but I did not check `flange` and `tool0` in packages that already have them. 

I have not yet added them to the SDA. I think that will require a bit more thought, and I want to make sure that I get it right.