### PR TITLE
Launch files can now be used with a space in path

### DIFF
--- a/motoman_ar2010_support/launch/view_ar2010.launch.xml
+++ b/motoman_ar2010_support/launch/view_ar2010.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_ar2010_support)/urdf/ar2010.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_ar2010_support)/urdf/ar2010.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_es_support/launch/view_es165.launch.xml
+++ b/motoman_es_support/launch/view_es165.launch.xml
@@ -1,10 +1,11 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_es_support)/urdf/es165.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_es_support)/urdf/es165.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
   <arg name="controller" description="Controller name (dx100, dx200) used to determine joint velocity limits" />
+  <let name="controller_path" value="'$(find-pkg-share motoman_es_support)/config/joint_velocities_$(var controller).yaml'" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="robot_description" type="str" value="$(command 'xacro $(var xacro_path) joint_velocities_file:=$(find-pkg-share motoman_es_support)/config/joint_velocities_$(var controller).yaml')" />
+    <param name="robot_description" type="str" value="$(command 'xacro $(var xacro_path) joint_velocities_file:=$(var controller_path)')" />
   </node>
   <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui" />
   <node pkg="rviz2" exec="rviz2" output="screen" args="-d $(var rviz_cfg)" />

--- a/motoman_es_support/launch/view_es200_120.launch.xml
+++ b/motoman_es_support/launch/view_es200_120.launch.xml
@@ -1,10 +1,11 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_es_support)/urdf/es200_120.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_es_support)/urdf/es200_120.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
   <arg name="controller" description="Controller name (dx100, dx200) used to determine joint velocity limits" />
+  <let name="controller_path" value="'$(find-pkg-share motoman_es_support)/config/joint_velocities_$(var controller).yaml'" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="robot_description" type="str" value="$(command 'xacro $(var xacro_path) joint_velocities_file:=$(find-pkg-share motoman_es_support)/config/joint_velocities_$(var controller).yaml')" />
+    <param name="robot_description" type="str" value="$(command 'xacro $(var xacro_path) joint_velocities_file:=$(var controller_path)')" />
   </node>
   <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui" />
   <node pkg="rviz2" exec="rviz2" output="screen" args="-d $(var rviz_cfg)" />

--- a/motoman_gp110_support/launch/view_gp110.launch.xml
+++ b/motoman_gp110_support/launch/view_gp110.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp110_support)/urdf/gp110.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp110_support)/urdf/gp110.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp12_support/launch/view_gp12.launch.xml
+++ b/motoman_gp12_support/launch/view_gp12.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp12_support)/urdf/gp12.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp12_support)/urdf/gp12.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp165r_support/launch/view_gp165r.launch.xml
+++ b/motoman_gp165r_support/launch/view_gp165r.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp165r_support)/urdf/gp165r.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp165r_support)/urdf/gp165r.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp165r_support/launch/view_gp165r_equipped.launch.xml
+++ b/motoman_gp165r_support/launch/view_gp165r_equipped.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp165r_support)/urdf/gp165r_equipped.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp165r_support)/urdf/gp165r_equipped.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp180_support/launch/view_gp180.launch.xml
+++ b/motoman_gp180_support/launch/view_gp180.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp180_support)/urdf/gp180.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp180_support)/urdf/gp180.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp180_support/launch/view_gp180_120.launch.xml
+++ b/motoman_gp180_support/launch/view_gp180_120.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp180_support)/urdf/gp180_120.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp180_support)/urdf/gp180_120.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp200r_support/launch/view_gp200r.launch.xml
+++ b/motoman_gp200r_support/launch/view_gp200r.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp200r_support)/urdf/gp200r.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp200r_support)/urdf/gp200r.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp20hl_support/launch/view_gp20hl.launch.xml
+++ b/motoman_gp20hl_support/launch/view_gp20hl.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp20hl_support)/urdf/gp20hl.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp20hl_support)/urdf/gp20hl.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp215_support/launch/view_gp215.launch.xml
+++ b/motoman_gp215_support/launch/view_gp215.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp215_support)/urdf/gp215.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp215_support)/urdf/gp215.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp225_support/launch/view_gp225.launch.xml
+++ b/motoman_gp225_support/launch/view_gp225.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp225_support)/urdf/gp225.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp225_support)/urdf/gp225.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp250_support/launch/view_gp250.launch.xml
+++ b/motoman_gp250_support/launch/view_gp250.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp250_support)/urdf/gp250.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp250_support)/urdf/gp250.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp25_support/launch/view_gp25.launch.xml
+++ b/motoman_gp25_support/launch/view_gp25.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp25_support)/urdf/gp25.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp25_support)/urdf/gp25.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp25_support/launch/view_gp25_12.launch.xml
+++ b/motoman_gp25_support/launch/view_gp25_12.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp25_support)/urdf/gp25_12.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp25_support)/urdf/gp25_12.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp25_support/launch/view_gp25_20.launch.xml
+++ b/motoman_gp25_support/launch/view_gp25_20.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp25_support)/urdf/gp25_20.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp25_support)/urdf/gp25_20.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp35l_support/launch/view_gp35l.launch.xml
+++ b/motoman_gp35l_support/launch/view_gp35l.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp35l_support)/urdf/gp35l.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp35l_support)/urdf/gp35l.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp4_support/launch/view_gp4.launch.xml
+++ b/motoman_gp4_support/launch/view_gp4.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp4_support)/urdf/gp4.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp4_support)/urdf/gp4.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp50_support/launch/view_gp50.launch.xml
+++ b/motoman_gp50_support/launch/view_gp50.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp50_support)/urdf/gp50.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp50_support)/urdf/gp50.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp70l_support/launch/view_gp70l.launch.xml
+++ b/motoman_gp70l_support/launch/view_gp70l.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp70l_support)/urdf/gp70l.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp70l_support)/urdf/gp70l.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp7_support/launch/view_gp7.launch.xml
+++ b/motoman_gp7_support/launch/view_gp7.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp7_support)/urdf/gp7.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp7_support)/urdf/gp7.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp88_support/launch/view_gp88.launch.xml
+++ b/motoman_gp88_support/launch/view_gp88.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp88_support)/urdf/gp88.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp88_support)/urdf/gp88.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp8_support/launch/view_gp8.launch.xml
+++ b/motoman_gp8_support/launch/view_gp8.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp8_support)/urdf/gp8.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp8_support)/urdf/gp8.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_gp8l_support/launch/view_gp8l.launch.xml
+++ b/motoman_gp8l_support/launch/view_gp8l.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_gp8l_support)/urdf/gp8l.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_gp8l_support)/urdf/gp8l.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc10_support/launch/view_hc10.launch.xml
+++ b/motoman_hc10_support/launch/view_hc10.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc10_support)/urdf/hc10.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc10_support)/urdf/hc10.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc10_support/launch/view_hc10dt.launch.xml
+++ b/motoman_hc10_support/launch/view_hc10dt.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc10_support)/urdf/hc10dt.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc10_support)/urdf/hc10dt.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc10_support/launch/view_hc10dt_b10.launch.xml
+++ b/motoman_hc10_support/launch/view_hc10dt_b10.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc10_support)/urdf/hc10dt_b10.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc10_support)/urdf/hc10dt_b10.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc10_support/launch/view_hc10dtp_b00.launch.xml
+++ b/motoman_hc10_support/launch/view_hc10dtp_b00.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc10_support)/urdf/hc10dtp_b00.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc10_support)/urdf/hc10dtp_b00.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc20_support/launch/view_hc20.launch.xml
+++ b/motoman_hc20_support/launch/view_hc20.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc20_support)/urdf/hc20.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc20_support)/urdf/hc20.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc20_support/launch/view_hc20_dtp.launch.xml
+++ b/motoman_hc20_support/launch/view_hc20_dtp.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc20_support)/urdf/hc20_dtp.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc20_support)/urdf/hc20_dtp.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_hc20_support/launch/view_hc30pl.launch.xml
+++ b/motoman_hc20_support/launch/view_hc30pl.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_hc20_support)/urdf/hc30pl.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_hc20_support)/urdf/hc30pl.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_ma2010_support/launch/view_ma2010.launch.xml
+++ b/motoman_ma2010_support/launch/view_ma2010.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_ma2010_support)/urdf/ma2010.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_ma2010_support)/urdf/ma2010.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_mh110_support/launch/view_mh110.launch.xml
+++ b/motoman_mh110_support/launch/view_mh110.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_mh110_support)/urdf/mh110.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_mh110_support)/urdf/mh110.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_mh12_support/launch/view_mh12.launch.xml
+++ b/motoman_mh12_support/launch/view_mh12.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_mh12_support)/urdf/mh12.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_mh12_support)/urdf/mh12.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_mh50_support/launch/view_mh50.launch.xml
+++ b/motoman_mh50_support/launch/view_mh50.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_mh50_support)/urdf/mh50.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_mh50_support)/urdf/mh50.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_mh5_support/launch/view_mh5.launch.xml
+++ b/motoman_mh5_support/launch/view_mh5.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_mh5_support)/urdf/mh5.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_mh5_support)/urdf/mh5.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_mh5_support/launch/view_mh5l.launch.xml
+++ b/motoman_mh5_support/launch/view_mh5l.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_mh5_support)/urdf/mh5l.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_mh5_support)/urdf/mh5l.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_motomini_support/launch/view_motomini.launch.xml
+++ b/motoman_motomini_support/launch/view_motomini.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_motomini_support)/urdf/motomini.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_motomini_support)/urdf/motomini.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_motopos_d500_support/launch/view_motopos_d500.launch.xml
+++ b/motoman_motopos_d500_support/launch/view_motopos_d500.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_motopos_d500_support)/urdf/motopos_d500.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_motopos_d500_support)/urdf/motopos_d500.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_motopos_mh1655_support/launch/view_motopos_mh1655.launch.xml
+++ b/motoman_motopos_mh1655_support/launch/view_motopos_mh1655.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_motopos_mh1655_support)/urdf/motopos_mh1655.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_motopos_mh1655_support)/urdf/motopos_mh1655.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_mpx1950_support/launch/view_mpx1950.launch.xml
+++ b/motoman_mpx1950_support/launch/view_mpx1950.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_mpx1950_support)/urdf/mpx1950.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_mpx1950_support)/urdf/mpx1950.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_ms210_support/launch/view_ms210.launch.xml
+++ b/motoman_ms210_support/launch/view_ms210.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_ms210_support)/urdf/ms210.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_ms210_support)/urdf/ms210.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sda10f_support/launch/view_csda10f.launch.xml
+++ b/motoman_sda10f_support/launch/view_csda10f.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sda10f_support)/urdf/csda10f.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sda10f_support)/urdf/csda10f.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sda10f_support/launch/view_sda10f.launch.xml
+++ b/motoman_sda10f_support/launch/view_sda10f.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sda10f_support)/urdf/sda10f.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sda10f_support)/urdf/sda10f.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sia10d_support/launch/view_sia10d.launch.xml
+++ b/motoman_sia10d_support/launch/view_sia10d.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sia10d_support)/urdf/sia10d.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sia10d_support)/urdf/sia10d.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sia10f_support/launch/view_sia10f.launch.xml
+++ b/motoman_sia10f_support/launch/view_sia10f.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sia10f_support)/urdf/sia10f.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sia10f_support)/urdf/sia10f.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sia20d_support/launch/view_sia20d.launch.xml
+++ b/motoman_sia20d_support/launch/view_sia20d.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sia20d_support)/urdf/sia20d.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sia20d_support)/urdf/sia20d.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sia30d_support/launch/view_sia30d.launch.xml
+++ b/motoman_sia30d_support/launch/view_sia30d.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sia30d_support)/urdf/sia30d.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sia30d_support)/urdf/sia30d.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sia50_support/launch/view_sia50.launch.xml
+++ b/motoman_sia50_support/launch/view_sia50.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sia50_support)/urdf/sia50.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sia50_support)/urdf/sia50.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_sia5d_support/launch/view_sia5d.launch.xml
+++ b/motoman_sia5d_support/launch/view_sia5d.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_sia5d_support)/urdf/sia5d.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_sia5d_support)/urdf/sia5d.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">

--- a/motoman_up50n_support/launch/view_up50n_35.launch.xml
+++ b/motoman_up50n_support/launch/view_up50n_35.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <let name="xacro_path" value="$(find-pkg-share motoman_up50n_support)/urdf/up50n_35.xacro" />
+  <let name="xacro_path" value="'$(find-pkg-share motoman_up50n_support)/urdf/up50n_35.xacro'" />
   <let name="rviz_cfg" value="$(find-pkg-share motoman_resources)/rviz/view_robot.rviz" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher">


### PR DESCRIPTION
Addresses #13

Before the launch files wouldn't work if the package path contained spaces. Now it works properly with and without spaces. 

I used @gavanderhoorn's suggestion from https://github.com/Yaskawa-Global/motoman_ros2_support_packages/issues/13#issuecomment-3442046216

The 2 launch files in the `motoman_es_support` vary slightly because they have an extra argument, but otherwise all of the launch files use the exact same line for the `robot_description` param command. 

I tested in both Humble and Jazzy. Jazzy works fine. It launches properly in Humble, but the links don't load because `rviz2` seemingly cannot find them with spaces in the path. Nothing crashes, the meshes just don't render. 