### PR TITLE
Move `xacro` end tag in `sia5d`

### DIFF
--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -191,7 +191,6 @@
       <parent link="${prefix}base_link"/>
       <child link="${prefix}base"/>
     </joint>
-    </xacro:macro>
 
   <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
   <link name="${prefix}flange"/>
@@ -209,5 +208,6 @@
     <child link="${prefix}tool0"/>
   </joint>
 
+  </xacro:macro>
 </robot>
 


### PR DESCRIPTION
Fixes problem introduced in #14 

I had a bad copy/paste when reordering the joints, so the `prefix` parameter couldn't be read