### PR TITLE
Avoid using semi-colons in xacro

### DIFF
--- a/motoman_ar2010_support/urdf/ar2010_macro.xacro
+++ b/motoman_ar2010_support/urdf/ar2010_macro.xacro
@@ -152,7 +152,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 0" rpy="0 ${pi/2} 0"/>
@@ -160,7 +160,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0"/>

--- a/motoman_es_support/urdf/es165_macro.xacro
+++ b/motoman_es_support/urdf/es165_macro.xacro
@@ -234,7 +234,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}link_t-flange" type="fixed">
       <origin xyz="0 0 0" rpy="0 ${radians(90)} 0"/>
@@ -242,7 +242,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_es_support/urdf/es200_120_macro.xacro
+++ b/motoman_es_support/urdf/es200_120_macro.xacro
@@ -232,7 +232,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_t-flange" type="fixed">
       <origin xyz="0 0 0" rpy="0 ${radians(90)} 0"/>
@@ -240,7 +240,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp110_support/urdf/gp110_macro.xacro
+++ b/motoman_gp110_support/urdf/gp110_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.200 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp12_support/urdf/gp12_macro.xacro
+++ b/motoman_gp12_support/urdf/gp12_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>

--- a/motoman_gp165r_support/urdf/gp165r_equipped_macro.xacro
+++ b/motoman_gp165r_support/urdf/gp165r_equipped_macro.xacro
@@ -152,7 +152,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 -0.225" rpy="0 0 0"/>
@@ -160,7 +160,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp165r_support/urdf/gp165r_macro.xacro
+++ b/motoman_gp165r_support/urdf/gp165r_macro.xacro
@@ -152,7 +152,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 -0.225" rpy="0 0 0"/>
@@ -160,7 +160,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp180_support/urdf/gp180_120_macro.xacro
+++ b/motoman_gp180_support/urdf/gp180_120_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -158,7 +158,7 @@
         <child link="${prefix}flange" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0" />
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />

--- a/motoman_gp180_support/urdf/gp180_macro.xacro
+++ b/motoman_gp180_support/urdf/gp180_macro.xacro
@@ -161,7 +161,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0 0 0" rpy="0 ${radians(90)} 0" />
@@ -169,7 +169,7 @@
         <child link="${prefix}flange" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0" />
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />

--- a/motoman_gp200r_support/urdf/gp200r_macro.xacro
+++ b/motoman_gp200r_support/urdf/gp200r_macro.xacro
@@ -152,7 +152,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -160,7 +160,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp20hl_support/urdf/gp20hl_macro.xacro
+++ b/motoman_gp20hl_support/urdf/gp20hl_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp215_support/urdf/gp215_macro.xacro
+++ b/motoman_gp215_support/urdf/gp215_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.250 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp225_support/urdf/gp225_macro.xacro
+++ b/motoman_gp225_support/urdf/gp225_macro.xacro
@@ -191,7 +191,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0.250 0 0" rpy="0 0 0" />
@@ -199,7 +199,7 @@
         <child link="${prefix}flange" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0" />
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />

--- a/motoman_gp250_support/urdf/gp250_macro.xacro
+++ b/motoman_gp250_support/urdf/gp250_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.250 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp25_support/urdf/gp25_12_macro.xacro
+++ b/motoman_gp25_support/urdf/gp25_12_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp25_support/urdf/gp25_20_macro.xacro
+++ b/motoman_gp25_support/urdf/gp25_20_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.105 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp25_support/urdf/gp25_macro.xacro
+++ b/motoman_gp25_support/urdf/gp25_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp35l_support/urdf/gp35l_macro.xacro
+++ b/motoman_gp35l_support/urdf/gp35l_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial flange frame attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.175 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial tool0 frame all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp4_support/urdf/gp4_macro.xacro
+++ b/motoman_gp4_support/urdf/gp4_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.072 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp50_support/urdf/gp50_macro.xacro
+++ b/motoman_gp50_support/urdf/gp50_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0.175 0 0" rpy="0 0 0" />
@@ -158,7 +158,7 @@
         <child link="${prefix}flange" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0" />
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />

--- a/motoman_gp70l_support/urdf/gp70l_macro.xacro
+++ b/motoman_gp70l_support/urdf/gp70l_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.175 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp7_support/urdf/gp7_macro.xacro
+++ b/motoman_gp7_support/urdf/gp7_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0.080 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
         <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp88_support/urdf/gp88_macro.xacro
+++ b/motoman_gp88_support/urdf/gp88_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0.175 0 0" rpy="0 0 0" />
@@ -158,7 +158,7 @@
         <child link="${prefix}flange" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp8_support/urdf/gp8_macro.xacro
+++ b/motoman_gp8_support/urdf/gp8_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.080 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_gp8l_support/urdf/gp8l_macro.xacro
+++ b/motoman_gp8l_support/urdf/gp8l_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.080 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_hc10_support/urdf/hc10_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0 0 -0.130" rpy="0 ${radians(90)} 0" />
@@ -158,7 +158,7 @@
         <child link="${prefix}flange" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0" />
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />

--- a/motoman_hc10_support/urdf/hc10dt_b10_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10dt_b10_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.170 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_hc10_support/urdf/hc10dt_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10dt_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 -0.170" rpy="0 ${radians(90)} 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_hc10_support/urdf/hc10dtp_b00_macro.xacro
+++ b/motoman_hc10_support/urdf/hc10dtp_b00_macro.xacro
@@ -152,7 +152,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.170 0 0" rpy="0 0 0"/>
@@ -160,7 +160,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_hc20_support/urdf/hc20_macro.xacro
+++ b/motoman_hc20_support/urdf/hc20_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.200 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_hc20_support/urdf/hc20dtp_macro.xacro
+++ b/motoman_hc20_support/urdf/hc20dtp_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.200 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_hc20_support/urdf/hc30pl_macro.xacro
+++ b/motoman_hc20_support/urdf/hc30pl_macro.xacro
@@ -156,7 +156,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 -0.200" rpy="0 0 0"/>
@@ -164,7 +164,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="0 ${radians(180)} ${radians(180)}"/>

--- a/motoman_ma2010_support/urdf/ma2010_macro.xacro
+++ b/motoman_ma2010_support/urdf/ma2010_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="3.1415926 -1.5707963 0"/>

--- a/motoman_mh110_support/urdf/mh110_macro.xacro
+++ b/motoman_mh110_support/urdf/mh110_macro.xacro
@@ -151,7 +151,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.200 0 0" rpy="0 0 0"/>
@@ -159,7 +159,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_mh12_support/urdf/mh12_macro.xacro
+++ b/motoman_mh12_support/urdf/mh12_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
     
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>

--- a/motoman_mh50_support/urdf/mh50_macro.xacro
+++ b/motoman_mh50_support/urdf/mh50_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
     
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.175 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>

--- a/motoman_mh5_support/urdf/mh5_macro.xacro
+++ b/motoman_mh5_support/urdf/mh5_macro.xacro
@@ -166,7 +166,7 @@
         <origin xyz="0 0 0.330" rpy="0 0 0"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <parent link="${prefix}link_6_t" />
@@ -174,7 +174,7 @@
       <origin xyz="0 0 0" rpy="0 0 0" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}joint_6_t-tool0" type="fixed">
         <parent link="${prefix}link_6_t"/>

--- a/motoman_mh5_support/urdf/mh5l_macro.xacro
+++ b/motoman_mh5_support/urdf/mh5l_macro.xacro
@@ -164,7 +164,7 @@
         <origin xyz="0 0 0.330" rpy="0 0 0"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange" />
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <parent link="${prefix}link_6_t" />
@@ -172,7 +172,7 @@
       <origin xyz="0 0 0" rpy="0 0 0" />
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}joint_6_t-tool0" type="fixed">
         <parent link="${prefix}link_6_t"/>

--- a/motoman_motomini_support/urdf/motomini_macro.xacro
+++ b/motoman_motomini_support/urdf/motomini_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-  <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+  <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0 0 -0.040" rpy="0 ${pi/2} 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0 " rpy="${pi} ${-pi/2} 0"/>

--- a/motoman_motopos_d500_support/urdf/motopos_d500_macro.xacro
+++ b/motoman_motopos_d500_support/urdf/motopos_d500_macro.xacro
@@ -70,7 +70,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
 
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_2-flange" type="fixed">
@@ -79,7 +79,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.14159265359"/>

--- a/motoman_motopos_mh1655_support/urdf/motopos_mh1655_macro.xacro
+++ b/motoman_motopos_mh1655_support/urdf/motopos_mh1655_macro.xacro
@@ -69,7 +69,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_1-flange" type="fixed">
       <origin xyz="0.2768 0 0" rpy="0 0 0"/>
@@ -77,7 +77,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${pi} ${-pi/2} 0"/>

--- a/motoman_mpx1950_support/urdf/mpx1950_macro.xacro
+++ b/motoman_mpx1950_support/urdf/mpx1950_macro.xacro
@@ -150,7 +150,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
       <origin xyz="0.100 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
       <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_ms210_support/urdf/ms210_macro.xacro
+++ b/motoman_ms210_support/urdf/ms210_macro.xacro
@@ -164,7 +164,7 @@
     <child link="${prefix}base"/>
   </joint>
 
-  <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+  <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
   <link name="${prefix}flange"/>
   <joint name="${prefix}joint_6_t-flange" type="fixed">
     <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -172,7 +172,7 @@
     <child link="${prefix}flange"/>
   </joint>
 
-  <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+  <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
   <link name="${prefix}tool0"/>
   <joint name="${prefix}flange-tool0" type="fixed">
     <origin xyz="0 0 0 " rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_resources/rviz/view_robot.rviz
+++ b/motoman_resources/rviz/view_robot.rviz
@@ -44,7 +44,7 @@ Visualization Manager:
         Z: 0
       Plane: XY
       Plane Cell Count: 10
-      Reference Frame: <Fixed Frame>
+      Reference frame, <Fixed Frame>
       Value: true
     - Class: rviz_default_plugins/TF
       Enabled: true
@@ -160,7 +160,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_link
+    Fixed frame, base_link
     Frame Rate: 30
   Name: root
   Tools:
@@ -219,7 +219,7 @@ Visualization Manager:
       Name: Current View
       Near Clip Distance: 0.009999999776482582
       Pitch: 0.4553983211517334
-      Target Frame: <Fixed Frame>
+      Target frame, <Fixed Frame>
       Value: Orbit (rviz)
       Yaw: 0.8653979301452637
     Saved: ~

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -203,7 +203,7 @@
             <child link="${prefix}base"/>
         </joint>
         
-        <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+        <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}joint_t-flange" type="fixed">
             <origin xyz="0 0 0" rpy="0 -1.57079632679 0"/>
@@ -211,7 +211,7 @@
             <child link="${prefix}flange"/>
         </joint>
 
-        <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+        <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
         <link name="${prefix}tool0"/>
         <joint name="${prefix}flange-tool0" type="fixed">
             <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.1415296"/>

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -189,7 +189,7 @@
             <child link="${prefix}base"/>
         </joint>
 
-        <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+        <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}joint_7_t-flange" type="fixed">
             <origin xyz="0 0 0" rpy="0 -1.57079632679 0"/>
@@ -197,7 +197,7 @@
             <child link="${prefix}flange"/>
         </joint>
 
-        <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+        <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
         <link name="${prefix}tool0"/>
         <joint name="${prefix}flange-tool0" type="fixed">
             <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.1415296"/>

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -189,7 +189,7 @@
             <child link="${prefix}base"/>
         </joint>
         
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}link_t-flange" type="fixed">
             <origin xyz="0 0 0" rpy="0 -1.57079632679 0"/>
@@ -197,7 +197,7 @@
             <child link="${prefix}flange"/>
         </joint>
 
-        <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+        <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
         <link name="${prefix}tool0"/>
         <joint name="${prefix}flange-tool0" type="fixed">
             <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.1415296"/>

--- a/motoman_sia30d_support/urdf/sia30d_macro.xacro
+++ b/motoman_sia30d_support/urdf/sia30d_macro.xacro
@@ -170,7 +170,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_7_t-flange" type="fixed">
         <origin xyz="0 0 0.217" rpy="0 ${radians(-90)} 0"/>
@@ -178,7 +178,7 @@
         <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0 " rpy="0 ${radians(-90)} ${radians(180)}"/>

--- a/motoman_sia50_support/urdf/sia50_macro.xacro
+++ b/motoman_sia50_support/urdf/sia50_macro.xacro
@@ -189,7 +189,7 @@
       <child link="${prefix}base"/>
     </joint>
     
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_t-flange" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -197,7 +197,7 @@
         <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0 " rpy="${radians(180)} ${radians(-90)} 0"/>

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -192,7 +192,7 @@
       <child link="${prefix}base"/>
     </joint>
 
-  <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+  <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
   <link name="${prefix}flange"/>
   <joint name="${prefix}joint_t-flange" type="fixed">
     <origin xyz="0.011 0 0" rpy="0 0 0"/>
@@ -200,7 +200,7 @@
     <child link="${prefix}flange"/>
   </joint>
 
-  <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+  <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
   <link name="${prefix}tool0"/>
   <joint name="${prefix}flange-tool0" type="fixed">
     <origin xyz="0 0 0 " rpy="${180*deg} ${-90*deg} 0"/>

--- a/motoman_up50n_support/urdf/up50n_35_macro.xacro
+++ b/motoman_up50n_support/urdf/up50n_35_macro.xacro
@@ -150,7 +150,7 @@
         <child link="${prefix}base"/>
     </joint>
 
-    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <!-- ROS-Industrial 'flange' frame, attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6_t-flange" type="fixed">
         <origin xyz="0.175 0 0" rpy="0 0 0"/>
@@ -158,7 +158,7 @@
         <child link="${prefix}flange"/>
     </joint>
 
-    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <!-- ROS-Industrial 'tool0' frame, all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
         <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>


### PR DESCRIPTION
Using colons in the xml comments breaks some implementation - For e.g., when loading params or values into a xacro using yaml. I propose replacing the colon with a comma instead to support. Alternatively we can also use a hyphen (-).