### PR TITLE
Standardize angle units to degrees

### DIFF
--- a/motoman_ar2010_support/urdf/ar2010_macro.xacro
+++ b/motoman_ar2010_support/urdf/ar2010_macro.xacro
@@ -110,35 +110,35 @@
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
-      <origin xyz="0.150 0 0" rpy="${pi/2} ${-pi/2} ${-pi}"/>
+      <origin xyz="0.150 0 0" rpy="${radians(90)} ${radians(-90)} ${radians(-180)}"/>
       <axis xyz="0 0 1"/>
       <limit lower="${radians(-105)}" upper="${radians(155)}" effort="3087" velocity="${radians(210)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
-      <origin xyz="0.760 0 0" rpy="${pi} 0 0"/>
+      <origin xyz="0.760 0 0" rpy="${radians(180)} 0 0"/>
       <axis xyz="0 0 1"/>
       <limit lower="${radians(-86)}" upper="${radians(160)}" effort="926.1" velocity="${radians(220)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
-      <origin xyz="0.200 -1.082 0" rpy="${-pi/2} 0 0"/>
+      <origin xyz="0.200 -1.082 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 1"/>
       <limit lower="${radians(-150)}" upper="${radians(150)}" effort="78.4" velocity="${radians(435)}"/>
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
-      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+      <origin xyz="0 0 0" rpy="${radians(90)} 0 0"/>
       <axis xyz="0 0 1"/>
       <limit lower="${radians(-135)}" upper="${radians(90)}" effort="67.03" velocity="${radians(435)}"/>
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
-      <origin xyz="0 -0.100 0" rpy="${-pi/2} 0 0"/>
+      <origin xyz="0 -0.100 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 1"/>
       <limit lower="${radians(-210)}" upper="${radians(210)}" effort="33.3" velocity="${radians(700)}"/>
     </joint>
@@ -155,7 +155,7 @@
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6-flange" type="fixed">
-      <origin xyz="0 0 0" rpy="0 ${pi/2} 0"/>
+      <origin xyz="0 0 0" rpy="0 ${radians(90)} 0"/>
       <parent link="${prefix}link_6"/>
       <child link="${prefix}flange"/>
     </joint>
@@ -163,7 +163,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_gp12_support/urdf/gp12_macro.xacro
+++ b/motoman_gp12_support/urdf/gp12_macro.xacro
@@ -103,42 +103,42 @@
         <child link="${prefix}link_1"/>
         <origin xyz="0 0 0.450" rpy="0 0 0" />
         <axis xyz="0 0 1" />
-        <limit lower="-2.9670" upper="2.9670" effort="926.10" velocity="4.5355"/>
+        <limit lower="${radians(-170)}" upper="${radians(170)}" effort="926.10" velocity="${radians(260)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
         <parent link="${prefix}link_1"/>
         <child link="${prefix}link_2"/>
         <origin xyz="0.155 0 0" rpy="0 0 0" />
         <axis xyz="0 1 0" />
-        <limit lower="-1.5708" upper="2.7052" effort="1029.00" velocity="4.0132"/>
+        <limit lower="${radians(-90)}" upper="${radians(155)}" effort="1029.00" velocity="${radians(230)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
         <parent link="${prefix}link_2"/>
         <child link="${prefix}link_3"/>
         <origin xyz="0 0 0.614" rpy="0 0 0" />
         <axis xyz="0 -1 0" />
-        <limit lower="-1.4835" upper="2.6179" effort="551.25" velocity="4.5375"/>
+        <limit lower="${radians(-85)}" upper="${radians(150)}" effort="551.25" velocity="${radians(260)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
         <parent link="${prefix}link_3"/>
         <child link="${prefix}link_4"/>
         <origin xyz="0.640 0 0.200" rpy="0 0 0" />
         <axis xyz="-1 0 0" />
-        <limit lower="-3.4906" upper="3.4906" effort="89.96" velocity="8.2007"/>
+        <limit lower="${radians(-200)}" upper="${radians(200)}" effort="89.96" velocity="${radians(470)}"/>
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
         <parent link="${prefix}link_4"/>
         <child link="${prefix}link_5"/>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <axis xyz="0 -1 0" />
-        <limit lower="-2.6179" upper="2.6179" effort="67.03" velocity="8.1992"/>
+        <limit lower="${radians(-150)}" upper="${radians(150)}" effort="67.03" velocity="${radians(470)}"/>
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
         <parent link="${prefix}link_5"/>
         <child link="${prefix}link_6"/>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <axis xyz="-1 0 0" />
-        <limit lower="-7.9412" upper="7.9412" effort="33.30" velocity="12.2143"/>
+        <limit lower="${radians(-455)}" upper="${radians(455)}" effort="33.30" velocity="${radians(700)}"/>
     </joint>
     <!-- end of joint list -->
 
@@ -161,7 +161,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_gp180_support/urdf/gp180_macro.xacro
+++ b/motoman_gp180_support/urdf/gp180_macro.xacro
@@ -33,14 +33,14 @@
     </link>
     <link name="${prefix}link_2">
         <visual>
-            <origin rpy="${radians(90)} ${radians(0)} ${radians(90)}" />
+            <origin rpy="${radians(90)} 0 ${radians(90)}" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180_120/visual/link_2.stl"/>
             </geometry>
             <xacro:material_yaskawa_blue/>
         </visual>
         <collision>
-            <origin rpy="${radians(90)} ${radians(0)} ${radians(90)}" />
+            <origin rpy="${radians(90)} 0 ${radians(90)}" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180_120/collision/link_2.stl"/>
             </geometry>
@@ -48,14 +48,14 @@
     </link>
     <link name="${prefix}link_3">
         <visual>
-            <origin rpy="${radians(-90)} ${radians(0)} ${radians(-90)}" />
+            <origin rpy="${radians(-90)} 0 ${radians(-90)}" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180/visual/link_3.stl"/>
             </geometry>
             <xacro:material_yaskawa_blue/>
         </visual>
         <collision>
-            <origin rpy="${radians(-90)} ${radians(0)} ${radians(-90)}" />
+            <origin rpy="${radians(-90)} 0 ${radians(-90)}" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180/collision/link_3.stl"/>
             </geometry>
@@ -63,14 +63,14 @@
     </link>
     <link name="${prefix}link_4">
         <visual>
-            <origin rpy="${radians(0)} ${radians(90)} ${radians(0)}" xyz="0 0 1.225"/>
+            <origin rpy="0 ${radians(90)} 0" xyz="0 0 1.225"/>
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180/visual/link_4.stl"/>
             </geometry>
             <xacro:material_yaskawa_blue/>
         </visual>
         <collision>
-            <origin rpy="${radians(0)} ${radians(90)} ${radians(0)}" xyz="0 0 1.225"/>
+            <origin rpy="0 ${radians(90)} 0" xyz="0 0 1.225"/>
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180/collision/link_4.stl"/>
             </geometry>
@@ -78,14 +78,14 @@
     </link>
     <link name="${prefix}link_5">
         <visual>
-            <origin rpy="${radians(-90)} ${radians(0)} ${radians(-90)}" />
+            <origin rpy="${radians(-90)} 0 ${radians(-90)}" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180_120/visual/link_5.stl"/>
             </geometry>
             <xacro:material_yaskawa_blue/>
         </visual>
         <collision>
-            <origin rpy="${radians(-90)} ${radians(0)} ${radians(-90)}" />
+            <origin rpy="${radians(-90)} 0 ${radians(-90)}" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180_120/collision/link_5.stl"/>
             </geometry>
@@ -93,14 +93,14 @@
     </link>
     <link name="${prefix}link_6">
         <visual>
-            <origin rpy="${radians(0)} ${radians(90)} ${radians(0)}" />
+            <origin rpy="0 ${radians(90)} 0" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180_120/visual/link_6.stl"/>
             </geometry>
             <xacro:material_yaskawa_blue/>
         </visual>
         <collision>
-            <origin rpy="${radians(0)} ${radians(90)} ${radians(0)}" />
+            <origin rpy="0 ${radians(90)} 0" />
             <geometry>
                 <mesh filename="package://motoman_gp180_support/meshes/gp180_120/collision/link_6.stl"/>
             </geometry>

--- a/motoman_gp180_support/urdf/gp180_macro.xacro
+++ b/motoman_gp180_support/urdf/gp180_macro.xacro
@@ -172,7 +172,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0" />
     <joint name="${prefix}flange-tool0" type="fixed">
-        <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+        <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0" />
         <parent link="${prefix}flange" />
         <child link="${prefix}tool0" />
     </joint>

--- a/motoman_gp20hl_support/urdf/gp20hl_macro.xacro
+++ b/motoman_gp20hl_support/urdf/gp20hl_macro.xacro
@@ -103,21 +103,21 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.540" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="5516.2" velocity="${radians(180.0)}"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="5516.2" velocity="${radians(180)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.145 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="${radians(-90)}" upper="${radians(135)}" effort="7060.7" velocity="${radians(180.0)}"/>
+      <limit lower="${radians(-90)}" upper="${radians(135)}" effort="7060.7" velocity="${radians(180)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 1.150" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-80)}" upper="${radians(206)}" effort="3089.0" velocity="${radians(180.0)}"/>
+      <limit lower="${radians(-80)}" upper="${radians(206)}" effort="3089.0" velocity="${radians(180)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>

--- a/motoman_gp215_support/urdf/gp215_macro.xacro
+++ b/motoman_gp215_support/urdf/gp215_macro.xacro
@@ -103,21 +103,21 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.650" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="9316.2" velocity="${radians(100.0)}"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="9316.2" velocity="${radians(100)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.285 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="${radians(-60)}" upper="${radians(76)}" effort="10591.1" velocity="${radians(90.0)}"/>
+      <limit lower="${radians(-60)}" upper="${radians(76)}" effort="10591.1" velocity="${radians(90)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 1.150" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-77.8)}" upper="${radians(197)}" effort="9929.2" velocity="${radians(97.0)}"/>
+      <limit lower="${radians(-77.8)}" upper="${radians(197)}" effort="9929.2" velocity="${radians(97)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>

--- a/motoman_gp250_support/urdf/gp250_macro.xacro
+++ b/motoman_gp250_support/urdf/gp250_macro.xacro
@@ -103,21 +103,21 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.650" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="9316.2" velocity="${radians(100.0)}"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="9316.2" velocity="${radians(100)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.285 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="${radians(-60)}" upper="${radians(76)}" effort="10591.1" velocity="${radians(90.0)}"/>
+      <limit lower="${radians(-60)}" upper="${radians(76)}" effort="10591.1" velocity="${radians(90)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 1.150" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-77.8)}" upper="${radians(197)}" effort="9929.2" velocity="${radians(97.0)}"/>
+      <limit lower="${radians(-77.8)}" upper="${radians(197)}" effort="9929.2" velocity="${radians(97)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>

--- a/motoman_gp35l_support/urdf/gp35l_macro.xacro
+++ b/motoman_gp35l_support/urdf/gp35l_macro.xacro
@@ -103,21 +103,21 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.540" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="5516.2" velocity="${radians(180.0)}"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="5516.2" velocity="${radians(180)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.145 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="${radians(-90)}" upper="${radians(135)}" effort="7060.7" velocity="${radians(140.0)}"/>
+      <limit lower="${radians(-90)}" upper="${radians(135)}" effort="7060.7" velocity="${radians(140)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 1.150" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-80)}" upper="${radians(206)}" effort="3089.0" velocity="${radians(178.0)}"/>
+      <limit lower="${radians(-80)}" upper="${radians(206)}" effort="3089.0" velocity="${radians(178)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>

--- a/motoman_gp70l_support/urdf/gp70l_macro.xacro
+++ b/motoman_gp70l_support/urdf/gp70l_macro.xacro
@@ -103,21 +103,21 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.540" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="3983.9" velocity="${radians(180.0)}"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="3983.9" velocity="${radians(180)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.320 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="${radians(-90)}" upper="${radians(155)}" effort="10174.4" velocity="${radians(123.0)}"/>
+      <limit lower="${radians(-90)}" upper="${radians(155)}" effort="10174.4" velocity="${radians(123)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 1.165" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="${radians(-80)}" upper="${radians(90)}" effort="5148.4" velocity="${radians(160.0)}"/>
+      <limit lower="${radians(-80)}" upper="${radians(90)}" effort="5148.4" velocity="${radians(160)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>

--- a/motoman_hc20_support/urdf/hc30pl_macro.xacro
+++ b/motoman_hc20_support/urdf/hc30pl_macro.xacro
@@ -74,14 +74,14 @@
         <geometry>
           <mesh filename="package://motoman_hc20_support/meshes/hc20dtp/visual/link_5.dae"/>
         </geometry>
-        <origin rpy="0 1.57075 0"/>
+        <origin rpy="0 ${radians(90)} 0"/>
         <xacro:material_yaskawa_white/>
       </visual>
       <collision>
         <geometry>
           <mesh filename="package://motoman_hc20_support/meshes/hc20dtp/collision/link_5.stl"/>
         </geometry>
-        <origin rpy="0 1.57075 0"/>
+        <origin rpy="0 ${radians(90)} 0"/>
       </collision>
     </link>
     <link name="${prefix}link_6">
@@ -89,14 +89,14 @@
         <geometry>
           <mesh filename="package://motoman_hc20_support/meshes/hc20dtp/visual/link_6.dae"/>
         </geometry>
-        <origin rpy="0 1.57075 0"/>
+        <origin rpy="0 ${radians(90)} 0"/>
         <xacro:material_yaskawa_white/>
       </visual>
       <collision>
         <geometry>
           <mesh filename="package://motoman_hc20_support/meshes/hc20dtp/collision/link_6.stl"/>
         </geometry>
-        <origin rpy="0 1.57075 0"/>
+        <origin rpy="0 ${radians(90)} 0"/>
       </collision>
     </link>
     <!-- end of link list -->

--- a/motoman_ma2010_support/urdf/ma2010_macro.xacro
+++ b/motoman_ma2010_support/urdf/ma2010_macro.xacro
@@ -103,42 +103,42 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.505" rpy="0 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="-3.1416" upper="3.1416" effort="3087" velocity="3.4383"/>
+      <limit lower="${radians(-180)}" upper="${radians(180)}" effort="3087" velocity="${radians(197)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.150 0 0" rpy="0 0 0" />
       <axis xyz="0 1 0" />
-      <limit lower="-1.8326" upper="2.7052" effort="2744" velocity="3.3161"/>
+      <limit lower="${radians(-105)}" upper="${radians(155)}" effort="2744" velocity="${radians(190)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 0.760" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="-1.5009" upper="2.7925" effort="874.65" velocity="3.6652"/>
+      <limit lower="${radians(-86)}" upper="${radians(160)}" effort="874.65" velocity="${radians(210)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
       <origin xyz="0 0 0.200" rpy="0 0 0" />
       <axis xyz="-1 0 0" />
-      <limit lower="-2.6180" upper="2.6180" effort="78.4" velocity="7.1558"/>
+      <limit lower="${radians(-150)}" upper="${radians(150)}" effort="78.4" velocity="${radians(410)}"/>
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
       <origin xyz="1.082 0 0" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="-2.3562" upper="1.5708" effort="59.58" velocity="7.1558"/>
+      <limit lower="${radians(-135)}" upper="${radians(90)}" effort="59.58" velocity="${radians(410)}"/>
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <axis xyz="-1 0 0" />
-      <limit lower="-3.6652" upper="3.6652" effort="29.6" velocity="10.6465"/>
+      <limit lower="${radians(-210)}" upper="${radians(210)}" effort="29.6" velocity="${radians(610)}"/>
     </joint>
     <!-- end of joint list -->
 
@@ -161,7 +161,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="3.1415926 -1.5707963 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_mh12_support/urdf/mh12_macro.xacro
+++ b/motoman_mh12_support/urdf/mh12_macro.xacro
@@ -161,7 +161,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_mh50_support/urdf/mh50_macro.xacro
+++ b/motoman_mh50_support/urdf/mh50_macro.xacro
@@ -103,42 +103,42 @@
         <child link="${prefix}link_1"/>
         <origin xyz="0 0 0.540" rpy="0 0 0" />
         <axis xyz="0 0 1" />
-        <limit lower="-3.14159" upper="3.14159" effort="4903.32" velocity="3.141"/>
+        <limit lower="${radians(-180)}" upper="${radians(180)}" effort="4903.32" velocity="${radians(180)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
         <parent link="${prefix}link_1"/>
         <child link="${prefix}link_2"/>
         <origin xyz="0.145 0 0" rpy="0 0 0" />
         <axis xyz="0 1 0" />
-        <limit lower="-1.57079" upper="2.35619" effort="6276.26" velocity="3.103"/>
+        <limit lower="${radians(-90)}" upper="${radians(135)}" effort="6276.26" velocity="${radians(178)}"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
         <parent link="${prefix}link_2"/>
         <child link="${prefix}link_3"/>
         <origin xyz="0 0 0.870" rpy="0 0 0" />
         <axis xyz="0 -1 0" />
-        <limit lower="-1.39626" upper="3.59538" effort="2745.86" velocity="3.106"/>
+        <limit lower="${radians(-80)}" upper="${radians(206)}" effort="2745.86" velocity="${radians(178)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
         <parent link="${prefix}link_3"/>
         <child link="${prefix}link_4"/>
         <origin xyz="1.025 0 0.210" rpy="0 0 0"/>
         <axis xyz="-1 0 0" />
-        <limit lower="-6.28319" upper="6.28319" effort="823.76" velocity="4.363"/>
+        <limit lower="${radians(-360)}" upper="${radians(360)}" effort="823.76" velocity="${radians(250)}"/>
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
         <parent link="${prefix}link_4"/>
         <child link="${prefix}link_5"/>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <axis xyz="0 -1 0" />
-        <limit lower="-2.18167" upper="2.18167" effort="706.08" velocity="4.363"/>
+        <limit lower="${radians(-125)}" upper="${radians(125)}" effort="706.08" velocity="${radians(250)}"/>
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
         <parent link="${prefix}link_5"/>
         <child link="${prefix}link_6"/>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <axis xyz="-1 0 0" />
-        <limit lower="-6.2831" upper="6.2831" effort="333.43" velocity="6.283"/>
+        <limit lower="${radians(-360)}" upper="${radians(360)}" effort="333.43" velocity="${radians(360)}"/>
     </joint>
     <!-- end of joint list -->
 
@@ -161,7 +161,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="3.1415926 -1.570796 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_mh5_support/urdf/mh5_macro.xacro
+++ b/motoman_mh5_support/urdf/mh5_macro.xacro
@@ -119,42 +119,42 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <axis xyz="0 0 1" />
-      <limit lower="-${radians(170)}" upper="${radians(170)}" effort="215.6" velocity="${radians(376)}" />
+      <limit lower="${radians(-170)}" upper="${radians(170)}" effort="215.6" velocity="${radians(376)}" />
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0.0880 0 0.00" rpy="0 0 0"/>
       <axis xyz="0 1 0" />
-      <limit lower="-${radians(65)}" upper="${radians(150)}" effort="176.4" velocity="${radians(350)}" />
+      <limit lower="${radians(-65)}" upper="${radians(150)}" effort="176.4" velocity="${radians(350)}" />
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 0.310" rpy="0 0 0"/>
       <axis xyz="0 -1 0" />
-      <limit lower="-${radians(70)}" upper="${radians(190)}" effort="76.8" velocity="${radians(400)}" />
+      <limit lower="${radians(-70)}" upper="${radians(190)}" effort="76.8" velocity="${radians(400)}" />
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
       <origin xyz="0 0 0.040" rpy="0 0 0"/>
       <axis xyz="-1 0 0" />
-      <limit lower="-${radians(190)}" upper="${radians(190)}" effort="44.7" velocity="${radians(450)}" />
+      <limit lower="${radians(-190)}" upper="${radians(190)}" effort="44.7" velocity="${radians(450)}" />
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
       <origin xyz="0.305 0 0" rpy="0 0 0"/>
       <axis xyz="0 -1 0" />
-      <limit lower="-${radians(135)}" upper="${radians(135)}" effort="18.0" velocity="${radians(450)}" />
+      <limit lower="${radians(-135)}" upper="${radians(135)}" effort="18.0" velocity="${radians(450)}" />
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
       <origin xyz="0.080 0 0" rpy="0 0 0"/>
       <axis xyz="-1 0 0" />
-      <limit lower="-${radians(360)}" upper="${radians(360)}" effort="18.0" velocity="${radians(720)}" />
+      <limit lower="${radians(-360)}" upper="${radians(360)}" effort="18.0" velocity="${radians(720)}" />
     </joint>
     <!-- end of joint list -->
 

--- a/motoman_mh5_support/urdf/mh5l_macro.xacro
+++ b/motoman_mh5_support/urdf/mh5l_macro.xacro
@@ -117,42 +117,42 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.330" rpy="0 0 0"/>
       <axis xyz="0 0 1" />
-      <limit lower="-${radians(170)}" upper="${radians(170)}" effort="303.8" velocity="${radians(270)}" />
+      <limit lower="${radians(-170)}" upper="${radians(170)}" effort="303.8" velocity="${radians(270)}" />
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
-      <origin xyz="0.0880 0 0.00" rpy="0 0 0"/>
+      <origin xyz="0.088 0 0" rpy="0 0 0"/>
       <axis xyz="0 1 0" />
-      <limit lower="-${radians(65)}" upper="${radians(150)}" effort="205.8" velocity="${radians(280)}" />
+      <limit lower="${radians(-65)}" upper="${radians(150)}" effort="205.8" velocity="${radians(280)}" />
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <origin xyz="0 0 0.400" rpy="0 0 0"/>
       <axis xyz="0 -1 0" />
-      <limit lower="-${radians(70)}" upper="${radians(190)}" effort="85.5" velocity="${radians(300)}" />
+      <limit lower="${radians(-70)}" upper="${radians(190)}" effort="85.5" velocity="${radians(300)}" />
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
       <origin xyz="0 0 0.040" rpy="0 0 0"/>
       <axis xyz="-1 0 0" />
-      <limit lower="-${radians(190)}" upper="${radians(190)}" effort="44.7" velocity="${radians(450)}" />
+      <limit lower="${radians(-190)}" upper="${radians(190)}" effort="44.7" velocity="${radians(450)}" />
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
       <origin xyz="0.405 0 0" rpy="0 0 0"/>
       <axis xyz="0 -1 0" />
-      <limit lower="-${radians(135)}" upper="${radians(135)}" effort="18.0" velocity="${radians(450)}" />
+      <limit lower="${radians(-135)}" upper="${radians(135)}" effort="18.0" velocity="${radians(450)}" />
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
       <origin xyz="0.080 0 0" rpy="0 0 0"/>
       <axis xyz="-1 0 0" />
-      <limit lower="-${radians(360)}" upper="${radians(360)}" effort="18.0" velocity="${radians(720)}" />
+      <limit lower="${radians(-360)}" upper="${radians(360)}" effort="18.0" velocity="${radians(720)}" />
     </joint>
     <!-- end of joint list -->
 

--- a/motoman_motomini_support/urdf/motomini_macro.xacro
+++ b/motoman_motomini_support/urdf/motomini_macro.xacro
@@ -103,42 +103,42 @@
     <child link="${prefix}link_1"/>
     <origin xyz="0 0 0.103" rpy="0 0 0" />
     <axis xyz="0 0 1" />
-    <limit lower="-2.9670" upper="2.9670" effort="0.12" velocity="5.4977"/>
+    <limit lower="${radians(-170)}" upper="${radians(170)}" effort="0.12" velocity="${radians(315)}"/>
   </joint>
   <joint name="${prefix}joint_2" type="revolute">
     <parent link="${prefix}link_1"/>
     <child link="${prefix}link_2"/>
     <origin xyz="0.020 0 0" rpy="0 0 0" />
     <axis xyz="0 1 0" />
-    <limit lower="-1.4835" upper="1.5707" effort="0.12" velocity="5.4977"/>
+    <limit lower="${radians(-85)}" upper="${radians(90)}" effort="0.12" velocity="${radians(315)}"/>
   </joint>
   <joint name="${prefix}joint_3" type="revolute">
     <parent link="${prefix}link_2"/>
     <child link="${prefix}link_3"/>
     <origin xyz="0 0 0.165" rpy="0 0 0" />
     <axis xyz="0 -1 0" />
-    <limit lower="-0.8726" upper="1.5707" effort="0.12" velocity="7.3304"/>
+    <limit lower="${radians(-50)}" upper="${radians(90)}" effort="0.12" velocity="${radians(420)}"/>
   </joint>
   <joint name="${prefix}joint_4" type="revolute">
     <parent link="${prefix}link_3"/>
     <child link="${prefix}link_4"/>
     <origin xyz="0.165 0 0" rpy="0 0 0" />
     <axis xyz="-1 0 0" />
-    <limit lower="-2.4434" upper="2.4434" effort="0.07" velocity="10.4719"/>
+    <limit lower="${radians(-140)}" upper="${radians(140)}" effort="0.07" velocity="${radians(600)}"/>
   </joint>
   <joint name="${prefix}joint_5" type="revolute">
     <parent link="${prefix}link_4"/>
     <child link="${prefix}link_5"/>
     <origin xyz="0 0 0" rpy="0 0 0" />
     <axis xyz="0 -1 0" />
-    <limit lower="-0.5235" upper="3.6651" effort="0.07" velocity="10.4719"/>
+    <limit lower="${radians(-30)}" upper="${radians(210)}" effort="0.07" velocity="${radians(600)}"/>
   </joint>
   <joint name="${prefix}joint_6" type="revolute">
     <parent link="${prefix}link_5"/>
     <child link="${prefix}link_6"/>
     <origin xyz="0 0 0" rpy="0 0 0" />
     <axis xyz="0 0 1" />
-    <limit lower="-6.2831" upper="6.2831" effort="0.07" velocity="10.4719"/>
+    <limit lower="${radians(-360)}" upper="${radians(360)}" effort="0.07" velocity="${radians(600)}"/>
   </joint>
     <!-- end of joint list -->
 
@@ -153,7 +153,7 @@
   <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_6-flange" type="fixed">
-      <origin xyz="0 0 -0.040" rpy="0 ${pi/2} 0"/>
+      <origin xyz="0 0 -0.040" rpy="0 ${radians(90)} 0"/>
       <parent link="${prefix}link_6"/>
       <child link="${prefix}flange"/>
     </joint>
@@ -161,7 +161,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0 " rpy="${pi} ${-pi/2} 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_motopos_d500_support/urdf/motopos_d500_macro.xacro
+++ b/motoman_motopos_d500_support/urdf/motopos_d500_macro.xacro
@@ -51,14 +51,14 @@
       <child link="${prefix}link_1"/>
       <origin xyz="0 0 0.380" rpy="0 0 0" />
       <axis xyz="0 -1 0" />
-      <limit lower="-2.3561" upper="2.3561" effort="1274" velocity="1.3962"/>
+      <limit lower="${radians(-135)}" upper="${radians(135)}" effort="1274" velocity="${radians(80)}"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <axis xyz="0 0 -1" />
-      <limit lower="-3.4906" upper="3.4906" effort="392" velocity="2.7925"/>
+      <limit lower="${radians(-200)}" upper="${radians(200)}" effort="392" velocity="${radians(160)}"/>
     </joint>
     <!-- end of joint list -->
 
@@ -74,7 +74,7 @@
 
     <link name="${prefix}flange"/>
     <joint name="${prefix}joint_2-flange" type="fixed">
-      <origin xyz="0 0 0.150 " rpy="0 -1.57079632679 0"/>
+      <origin xyz="0 0 0.150" rpy="0 ${radians(-90)} 0"/>
       <parent link="${prefix}link_2"/>
       <child link="${prefix}flange"/>
     </joint>
@@ -82,7 +82,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.14159265359"/>
+      <origin xyz="0 0 0" rpy="0 ${radians(-90)} ${radians(180)}"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_motopos_mh1655_support/urdf/motopos_mh1655_macro.xacro
+++ b/motoman_motopos_mh1655_support/urdf/motopos_mh1655_macro.xacro
@@ -57,7 +57,7 @@
       <axis xyz="1 0 0"/>
       <!-- NOTE: the velocity limit is a conservative conversion from the stated
            limit in the manual: 10.8 rpm (in section 3.2.1) -->
-      <limit lower="${-2*pi}" upper="${2*pi}" effort="1274" velocity="1.1309"/>
+      <limit lower="${radians(-360)}" upper="${radians(360)}" effort="1274" velocity="${radians(65)}"/>
     </joint>
     <!-- end of joint list -->
 
@@ -80,7 +80,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="${pi} ${-pi/2} 0"/>
+      <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_ms210_support/urdf/ms210_macro.xacro
+++ b/motoman_ms210_support/urdf/ms210_macro.xacro
@@ -175,7 +175,7 @@
   <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
   <link name="${prefix}tool0"/>
   <joint name="${prefix}flange-tool0" type="fixed">
-    <origin xyz="0 0 0 " rpy="${radians(180)} ${radians(-90)} 0"/>
+    <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
     <parent link="${prefix}flange"/>
     <child link="${prefix}tool0"/>
   </joint>

--- a/motoman_sda10f_support/urdf/arm_macro.xacro
+++ b/motoman_sda10f_support/urdf/arm_macro.xacro
@@ -109,49 +109,49 @@
     <joint name="${prefix}joint_1" type="revolute">
       <parent link="${parent}"/>
       <child link="${prefix}link_1"/>
-      <origin xyz="0.100 ${reflect*0.265} 0.0" rpy="${radians(90)} 0.0 ${(reflect-1)*radians(90)}"/>
+      <origin xyz="0.100 ${reflect*0.265} 0" rpy="${radians(90)} 0 ${(reflect-1)*radians(90)}"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
-      <origin xyz="0.0 0.0 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-110)}" upper="${radians(110)}" effort="0" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
-      <origin xyz="0.0 0.360 0.0" rpy="${radians(90)} 0.0 0.0"/>
+      <origin xyz="0 0.360 0" rpy="${radians(90)} 0 0"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-170)}" upper="${radians(170)}" effort="0" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
-      <origin xyz="0.0 0.0 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${reflect}" />
       <limit lower="${radians(-135)}" upper="${radians(135)}" effort="0" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
-      <origin xyz="0.0 0.360 0.0" rpy="${radians(90)} 0.0 0.0"/>
+      <origin xyz="0 0.360 0" rpy="${radians(90)} 0 0"/>
       <axis xyz="0 0 ${reflect}" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(200)}" />
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
-      <origin xyz="0.0 0.0 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${reflect}" />
       <limit lower="${radians(-110)}" upper="${radians(110)}" effort="0" velocity="${radians(200)}" />
     </joint>
     <joint name="${prefix}joint_7" type="revolute">
       <parent link="${prefix}link_6"/>
       <child link="${prefix}link_7"/>
-      <origin xyz="0.0 0.155 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0.155 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(400)}" />
     </joint>

--- a/motoman_sda10f_support/urdf/csda10f_arm_macro.xacro
+++ b/motoman_sda10f_support/urdf/csda10f_arm_macro.xacro
@@ -109,49 +109,49 @@
     <joint name="${prefix}joint_1" type="revolute">
       <parent link="${parent}"/>
       <child link="${prefix}link_1"/>
-      <origin xyz="0.100 ${reflect*0.265} 0.0" rpy="${radians(90)} 0.0 ${(reflect-1)*radians(90)}"/>
+      <origin xyz="0.100 ${reflect*0.265} 0" rpy="${radians(90)} 0 ${(reflect-1)*radians(90)}"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-170)}" upper="${radians(170)}" effort="268.36" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
-      <origin xyz="0.0 0.0 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-110)}" upper="${radians(110)}" effort="268.36" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
-      <origin xyz="0.0 0.360 0.0" rpy="${radians(90)} 0.0 0.0"/>
+      <origin xyz="0 0.360 0" rpy="${radians(90)} 0 0"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-170)}" upper="${radians(170)}" effort="122.89" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
-      <origin xyz="0.0 0.0 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${reflect}" />
       <limit lower="${radians(-135)}" upper="${radians(135)}" effort="122.89" velocity="${radians(170)}" />
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
-      <origin xyz="0.0 0.360 0.0" rpy="${radians(90)} 0.0 0.0"/>
+      <origin xyz="0 0.360 0" rpy="${radians(90)} 0 0"/>
       <axis xyz="0 0 ${reflect}" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="44.34" velocity="${radians(200)}" />
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>
-      <origin xyz="0.0 0.0 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${reflect}" />
       <limit lower="${radians(-110)}" upper="${radians(110)}" effort="44.34" velocity="${radians(200)}" />
     </joint>
     <joint name="${prefix}joint_7" type="revolute">
       <parent link="${prefix}link_6"/>
       <child link="${prefix}link_7"/>
-      <origin xyz="0.0 0.175 0.0" rpy="${radians(-90)} 0.0 0.0"/>
+      <origin xyz="0 0.175 0" rpy="${radians(-90)} 0 0"/>
       <axis xyz="0 0 ${-reflect}" />
       <limit lower="${radians(-180)}" upper="${radians(180)}" effort="39.04" velocity="${radians(400)}" />
     </joint>

--- a/motoman_sda10f_support/urdf/sda10f_macro.xacro
+++ b/motoman_sda10f_support/urdf/sda10f_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find motoman_sda10f_support)/urdf/common_torso_macro.xacro" />
   <xacro:include filename="$(find motoman_sda10f_support)/urdf/arm_macro.xacro" />
 
-  <xacro:macro name="motoman_sda10f" params="prefix left_arm_prefix right_arm_prefix left_base_prefix right_base_prefix ">
+  <xacro:macro name="motoman_sda10f" params="prefix left_arm_prefix right_arm_prefix left_base_prefix right_base_prefix">
     <xacro:torso name="${prefix}torso" prefix="${prefix}"  left_base_prefix="${left_base_prefix}" right_base_prefix="${right_base_prefix}"/>
 
     <xacro:motoman_arm name="${prefix}${left_arm_prefix}arm" prefix="${prefix}${left_arm_prefix}" parent="${prefix}${left_base_prefix}base_link" reflect="1">

--- a/motoman_sia10d_support/urdf/sia10d_macro.xacro
+++ b/motoman_sia10d_support/urdf/sia10d_macro.xacro
@@ -38,14 +38,14 @@
 
         <link name="${prefix}link_2">
             <visual>
-                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/link_2.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/link_2.stl" />
                 </geometry>
@@ -55,14 +55,14 @@
 
         <link name="${prefix}link_3">
             <visual>
-                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/link_3.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_silver/>
             </visual>
             <collision>
-                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/link_3.stl" />
                 </geometry>
@@ -72,14 +72,14 @@
 
         <link name="${prefix}link_4">
             <visual>
-                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(-180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/link_4.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(-180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/link_4.stl" />
                 </geometry>
@@ -89,14 +89,14 @@
 
         <link name="${prefix}link_5">
             <visual>
-                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/link_5.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_silver/>
             </visual>
             <collision>
-                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/link_5.stl" />
                 </geometry>
@@ -107,14 +107,14 @@
 
         <link name="${prefix}link_6">
             <visual>
-                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(-90)} 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/visual/link_6.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(-90)} 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10d_support/meshes/sia10d/collision/link_6.stl" />
                 </geometry>
@@ -149,49 +149,49 @@
             <child link="${prefix}link_1"/>
             <origin xyz="0 0 0.36" rpy="0 0 0"/>
             <axis xyz="0 0 1" />
-            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.9670" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="100" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_2" type="revolute">
             <parent link="${prefix}link_1"/>
             <child link="${prefix}link_2"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 1 0" />
-            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.9670" />
+            <limit lower="${radians(-110)}" upper="${radians(110)}" effort="100" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_3" type="revolute">
             <parent link="${prefix}link_2"/>
             <child link="${prefix}link_3"/>
             <origin xyz="0 0 0.36" rpy="0 0 0"/>
             <axis xyz="0 0 1" />
-            <limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
+            <limit lower="${radians(-170)}" upper="${radians(170)}" effort="100" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_4" type="revolute">
             <parent link="${prefix}link_3"/>
             <child link="${prefix}link_4"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 -1 0" />
-            <limit lower="-2.3561" upper="2.3561" effort="100" velocity="2.9670" />
+            <limit lower="${radians(-135)}" upper="${radians(135)}" effort="100" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_5" type="revolute">
             <parent link="${prefix}link_4"/>
             <child link="${prefix}link_5"/>
             <origin xyz="0 0 0.360" rpy="0 0 0"/>
             <axis xyz="0 0 -1" />
-            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="100" velocity="${radians(200)}" />
         </joint>
         <joint name="${prefix}joint_6" type="revolute">
             <parent link="${prefix}link_5"/>
             <child link="${prefix}link_6"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 -1 0" />
-            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
+            <limit lower="${radians(-110)}" upper="${radians(110)}" effort="100" velocity="${radians(200)}" />
         </joint>
         <joint name="${prefix}joint_7" type="revolute">
             <parent link="${prefix}link_6"/>
             <child link="${prefix}link_7"/>
             <origin xyz="0 0 0.155" rpy="0 0 0"/>
             <axis xyz="0 0 -1" />
-            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="100" velocity="${radians(400)}" />
         </joint>
         <!-- end of joint list -->
 
@@ -206,7 +206,7 @@
         <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}joint_7-flange" type="fixed">
-            <origin xyz="0 0 0" rpy="0 -1.57079632679 0"/>
+            <origin xyz="0 0 0" rpy="0 ${radians(-90)} 0"/>
             <parent link="${prefix}link_7"/>
             <child link="${prefix}flange"/>
         </joint>
@@ -214,7 +214,7 @@
         <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
         <link name="${prefix}tool0"/>
         <joint name="${prefix}flange-tool0" type="fixed">
-            <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.1415296"/>
+            <origin xyz="0 0 0" rpy="0 ${radians(-90)} ${radians(180)}"/>
             <parent link="${prefix}flange"/>
             <child link="${prefix}tool0"/>
         </joint>

--- a/motoman_sia10f_support/urdf/sia10f_macro.xacro
+++ b/motoman_sia10f_support/urdf/sia10f_macro.xacro
@@ -36,14 +36,14 @@
         </link>
         <link name="${prefix}link_2">
             <visual>
-                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/link_2.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="1.57 3.1416 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/link_2.stl" />
                 </geometry>
@@ -52,14 +52,14 @@
         </link>
         <link name="${prefix}link_3">
             <visual>
-                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/link_3.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_white/>
             </visual>
             <collision>
-                <origin rpy="0 0 3.1415" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/link_3.stl" />
                 </geometry>
@@ -68,14 +68,14 @@
         </link>
         <link name="${prefix}link_4">
             <visual>
-                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(-180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/link_4.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="1.57 -3.1415 0" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(-180)} 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/link_4.stl" />
                 </geometry>
@@ -84,14 +84,14 @@
         </link>
         <link name="${prefix}link_5">
             <visual>
-                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/link_5.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_white/>
             </visual>
             <collision>
-                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/link_5.stl" />
                 </geometry>
@@ -100,14 +100,14 @@
         </link>
         <link name="${prefix}link_6">
             <visual>
-                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(-90)} 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/visual/link_6.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="-1.57 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(-90)} 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia10f_support/meshes/sia10f/collision/link_6.stl" />
                 </geometry>
@@ -135,49 +135,49 @@
             <child link="${prefix}link_1"/>
             <origin xyz="0 0 0.36" rpy="0 0 0"/>
             <axis xyz="0 0 1" />
-            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="2.9670" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_2" type="revolute">
             <parent link="${prefix}link_1"/>
             <child link="${prefix}link_2"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 1 0" />
-            <limit lower="-1.9198" upper="1.9198" effort="0" velocity="2.9670" />
+            <limit lower="${radians(-110)}" upper="${radians(110)}" effort="0" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_3" type="revolute">
             <parent link="${prefix}link_2"/>
             <child link="${prefix}link_3"/>
             <origin xyz="0 0 0.36" rpy="0 0 0"/>
             <axis xyz="0 0 1" />
-            <limit lower="-2.9670" upper="2.9670" effort="0" velocity="2.9670" />
+            <limit lower="${radians(-170)}" upper="${radians(170)}" effort="0" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_4" type="revolute">
             <parent link="${prefix}link_3"/>
             <child link="${prefix}link_4"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 -1 0" />
-            <limit lower="-2.3561" upper="2.3561" effort="0" velocity="2.9670" />
+            <limit lower="${radians(-135)}" upper="${radians(135)}" effort="0" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_5" type="revolute">
             <parent link="${prefix}link_4"/>
             <child link="${prefix}link_5"/>
             <origin xyz="0 0 0.360" rpy="0 0 0"/>
             <axis xyz="0 0 -1" />
-            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="3.4906" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(200)}" />
         </joint>
         <joint name="${prefix}joint_6" type="revolute">
             <parent link="${prefix}link_5"/>
             <child link="${prefix}link_6"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 -1 0" />
-            <limit lower="-1.9198" upper="1.9198" effort="0" velocity="3.4906" />
+            <limit lower="${radians(-110)}" upper="${radians(110)}" effort="0" velocity="${radians(200)}" />
         </joint>
         <joint name="${prefix}joint_7" type="revolute">
             <parent link="${prefix}link_6"/>
             <child link="${prefix}link_7"/>
             <origin xyz="0 0 0.155" rpy="0 0 0"/>
             <axis xyz="0 0 -1" />
-            <limit lower="-3.1415" upper="3.1415" effort="0" velocity="6.9813" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(400)}" />
         </joint>
         <!-- end of joint list -->
 
@@ -192,7 +192,7 @@
         <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}joint_7-flange" type="fixed">
-            <origin xyz="0 0 0" rpy="0 -1.57079632679 0"/>
+            <origin xyz="0 0 0" rpy="0 ${radians(-90)} 0"/>
             <parent link="${prefix}link_7"/>
             <child link="${prefix}flange"/>
         </joint>
@@ -200,7 +200,7 @@
         <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
         <link name="${prefix}tool0"/>
         <joint name="${prefix}flange-tool0" type="fixed">
-            <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.1415296"/>
+            <origin xyz="0 0 0" rpy="0 ${radians(-90)} ${radians(180)}"/>
             <parent link="${prefix}flange"/>
             <child link="${prefix}tool0"/>
         </joint>

--- a/motoman_sia20d_support/urdf/sia20d_macro.xacro
+++ b/motoman_sia20d_support/urdf/sia20d_macro.xacro
@@ -20,14 +20,14 @@
         </link>
         <link name="${prefix}link_1">
             <visual>
-                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/link_1.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_white/>
             </visual>
             <collision>
-                <origin rpy="0 0 3.1416" xyz="0 0 0"/>
+                <origin rpy="0 0 ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/link_1.stl" />
                 </geometry>
@@ -36,14 +36,14 @@
         </link>
         <link name="${prefix}link_2">
             <visual>
-                <origin rpy="1.57 3.1416 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(180)} ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/link_2.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="1.57 3.1416 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(180)} ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/link_2.stl"/>
                 </geometry>
@@ -68,14 +68,14 @@
         </link>
         <link name="${prefix}link_4">
             <visual>
-                <origin rpy="1.57 -3.1415 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(-180)} ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/link_4.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="1.57 -3.1415 3.1416" xyz="0 0 0"/>
+                <origin rpy="${radians(90)} ${radians(-180)} ${radians(180)}" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/link_4.stl"/>
                 </geometry>
@@ -100,14 +100,14 @@
         </link>
         <link name="${prefix}link_6">
             <visual>
-                <origin rpy="-1.57 0 0" xyz="0 0 0"/>
+                <origin rpy="${radians(-90)} 0 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/visual/link_6.stl"/>
                 </geometry>
                 <xacro:material_yaskawa_blue/>
             </visual>
             <collision>
-                <origin rpy="-1.57 0 0" xyz="0 0 0"/>
+                <origin rpy="${radians(-90)} 0 0" xyz="0 0 0"/>
                 <geometry>
                     <mesh filename="package://motoman_sia20d_support/meshes/sia20d/collision/link_6.stl"/>
                 </geometry>
@@ -135,49 +135,49 @@
             <child link="${prefix}link_1"/>
             <origin xyz="0 0 0.41" rpy="0 0 0"/>
             <axis xyz="0 0 1" />
-            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="2.2689" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="100" velocity="${radians(130)}" />
         </joint>
         <joint name="${prefix}joint_2" type="revolute">
             <parent link="${prefix}link_1"/>
             <child link="${prefix}link_2"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 1 0" />
-            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="2.2689" />
+            <limit lower="${radians(-110)}" upper="${radians(110)}" effort="100" velocity="${radians(130)}" />
         </joint>
         <joint name="${prefix}joint_3" type="revolute">
             <parent link="${prefix}link_2"/>
             <child link="${prefix}link_3"/>
             <origin xyz="0 0 0.49" rpy="0 0 0"/>
             <axis xyz="0 0 1" />
-            <limit lower="-2.9670" upper="2.9670" effort="100" velocity="2.9670" />
+            <limit lower="${radians(-170)}" upper="${radians(170)}" effort="100" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_4" type="revolute">
             <parent link="${prefix}link_3"/>
             <child link="${prefix}link_4"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 -1 0" />
-            <limit lower="-2.2689" upper="2.2689" effort="100" velocity="2.9670" />
+            <limit lower="${radians(-130)}" upper="${radians(130)}" effort="100" velocity="${radians(170)}" />
         </joint>
         <joint name="${prefix}joint_5" type="revolute">
             <parent link="${prefix}link_4"/>
             <child link="${prefix}link_5"/>
             <origin xyz="0 0 0.420" rpy="0 0 0"/>
             <axis xyz="0 0 -1" />
-            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="3.4906" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="100" velocity="${radians(200)}" />
         </joint>
         <joint name="${prefix}joint_6" type="revolute">
             <parent link="${prefix}link_5"/>
             <child link="${prefix}link_6"/>
             <origin xyz="0 0 0" rpy="0 0 0"/>
             <axis xyz="0 -1 0" />
-            <limit lower="-1.9198" upper="1.9198" effort="100" velocity="3.4906" />
+            <limit lower="${radians(-110)}" upper="${radians(110)}" effort="100" velocity="${radians(200)}" />
         </joint>
         <joint name="${prefix}joint_7" type="revolute">
             <parent link="${prefix}link_6"/>
             <child link="${prefix}link_7"/>
             <origin xyz="0 0 0.18" rpy="0 0 0"/>
             <axis xyz="0 0 -1" />
-            <limit lower="-3.1415" upper="3.1415" effort="100" velocity="6.9813" />
+            <limit lower="${radians(-180)}" upper="${radians(180)}" effort="100" velocity="${radians(400)}" />
         </joint>
         <!-- end of joint list -->
 
@@ -192,7 +192,7 @@
     <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
         <link name="${prefix}flange"/>
         <joint name="${prefix}joint_7-flange" type="fixed">
-            <origin xyz="0 0 0" rpy="0 -1.57079632679 0"/>
+            <origin xyz="0 0 0" rpy="0 ${radians(-90)} 0"/>
             <parent link="${prefix}link_7"/>
             <child link="${prefix}flange"/>
         </joint>
@@ -200,7 +200,7 @@
         <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
         <link name="${prefix}tool0"/>
         <joint name="${prefix}flange-tool0" type="fixed">
-            <origin xyz="0 0 0 " rpy="0 -1.57079632679 3.1415296"/>
+            <origin xyz="0 0 0" rpy="0 ${radians(-90)} ${radians(180)}"/>
             <parent link="${prefix}flange"/>
             <child link="${prefix}tool0"/>
         </joint>

--- a/motoman_sia30d_support/urdf/sia30d_macro.xacro
+++ b/motoman_sia30d_support/urdf/sia30d_macro.xacro
@@ -181,7 +181,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-        <origin xyz="0 0 0 " rpy="0 ${radians(-90)} ${radians(180)}"/>
+        <origin xyz="0 0 0" rpy="0 ${radians(-90)} ${radians(180)}"/>
         <parent link="${prefix}flange"/>
         <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_sia50_support/urdf/sia50_macro.xacro
+++ b/motoman_sia50_support/urdf/sia50_macro.xacro
@@ -200,7 +200,7 @@
     <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-        <origin xyz="0 0 0 " rpy="${radians(180)} ${radians(-90)} 0"/>
+        <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
         <parent link="${prefix}flange"/>
         <child link="${prefix}tool0"/>
     </joint>

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -42,7 +42,7 @@
     <parent link="${prefix}base_link" />
     <child link="${prefix}link_1" />
     <axis xyz="0 0 1" />
-    <limit lower="${-180*deg}" upper="${180*deg}" effort="0" velocity="${200*deg}" />
+    <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(200)}" />
   </joint>
 
   <link name="${prefix}link_2">
@@ -65,7 +65,7 @@
     <parent link="${prefix}link_1" />
     <child link="${prefix}link_2" />
     <axis xyz="0 1 0" />
-    <limit lower="${-110*deg}" upper="${110*deg}" effort="0" velocity="${200*deg}" />
+    <limit lower="${radians(-110)}" upper="${radians(110)}" effort="0" velocity="${radians(200)}" />
   </joint>
 
   <link name="${prefix}link_3">
@@ -88,7 +88,7 @@
     <parent link="${prefix}link_2" />
     <child link="${prefix}link_3" />
     <axis xyz="0 0 1" />
-    <limit lower="${-170*deg}" upper="${170*deg}" effort="0" velocity="${200*deg}" />
+    <limit lower="${radians(-170)}" upper="${radians(170)}" effort="0" velocity="${radians(200)}" />
   </joint>
   
   <link name="${prefix}link_4">
@@ -111,7 +111,7 @@
     <parent link="${prefix}link_3" />
     <child link="${prefix}link_4" />
     <axis xyz="0 -1 0" />
-    <limit lower="${-90*deg}" upper="${115*deg}" effort="0"  velocity="${200*deg}" />
+    <limit lower="${radians(-90)}" upper="${radians(115)}" effort="0" velocity="${radians(200)}" />
   </joint>
 
   <link name="${prefix}link_5">
@@ -134,7 +134,7 @@
     <parent link="${prefix}link_4" />
     <child link="${prefix}link_5" />
     <axis xyz="-1 0 0" />
-    <limit lower="${-90*deg}" upper="${90*deg}" effort="0" velocity="${200*deg}" />
+    <limit lower="${radians(-90)}" upper="${radians(90)}" effort="0" velocity="${radians(200)}" />
   </joint>
 
   <link name="${prefix}link_6">
@@ -157,7 +157,7 @@
     <parent link="${prefix}link_5" />
     <child link="${prefix}link_6" />
     <axis xyz="0 -1 0" />
-    <limit lower="${-110*deg}" upper="${110*deg}" effort="0" velocity="${230*deg}" />
+    <limit lower="${radians(-110)}" upper="${radians(110)}" effort="0" velocity="${radians(230)}" />
   </joint>
 
   <link name="${prefix}link_7">
@@ -180,7 +180,7 @@
     <parent link="${prefix}link_6" />
     <child link="${prefix}link_7" />
     <axis xyz="-1 0 0" />
-    <limit lower="${-90*deg}" upper="${90*deg}" effort="0" velocity="${350*deg}" />
+    <limit lower="${radians(-90)}" upper="${radians(90)}" effort="0" velocity="${radians(350)}" />
   </joint>
   <!-- end of joint list -->
   
@@ -203,7 +203,7 @@
   <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
   <link name="${prefix}tool0"/>
   <joint name="${prefix}flange-tool0" type="fixed">
-    <origin xyz="0 0 0 " rpy="${180*deg} ${-90*deg} 0"/>
+    <origin xyz="0 0 0" rpy="${radians(180)} ${radians(-90)} 0"/>
     <parent link="${prefix}flange"/>
     <child link="${prefix}tool0"/>
   </joint>

--- a/motoman_sia5d_support/urdf/sia5d_macro.xacro
+++ b/motoman_sia5d_support/urdf/sia5d_macro.xacro
@@ -1,7 +1,5 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-
-    <xacro:property name="deg" value="0.017453293" /> <!--degrees to radians-->
     
     <xacro:macro name="motoman_sia5d" params="prefix">
 


### PR DESCRIPTION
Should close #12 

Standardizes angle units to degrees to match the parameter extractor and manuals. 

I have several commits [here](https://github.com/Yaskawa-Global/motoman_ros2_support_packages/tree/rad_to_deg) that depend upon this (correcting incorrect joint limits). 