### PR TITLE
Fix inaccurate link_3 ranges

### DIFF
--- a/motoman_mh12_support/urdf/mh12_macro.xacro
+++ b/motoman_mh12_support/urdf/mh12_macro.xacro
@@ -117,7 +117,7 @@
         <child link="${prefix}link_3"/>
         <origin xyz="0 0 0.614" rpy="0 0 0" />
         <axis xyz="0 -1 0" />
-        <limit lower="${radians(-175)}" upper="${radians(240)}" effort="257.25" velocity="${radians(220)}"/>
+        <limit lower="${radians(-85)}" upper="${radians(150)}" effort="257.25" velocity="${radians(220)}"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
         <parent link="${prefix}link_3"/>

--- a/motoman_ms210_support/urdf/ms210_macro.xacro
+++ b/motoman_ms210_support/urdf/ms210_macro.xacro
@@ -131,7 +131,7 @@
     <child link="${prefix}link_3" />
     <origin xyz="0 0 1.150" rpy="0 0 0" />
     <axis xyz="0 -1 0" />
-    <limit lower="${radians(-147)}" upper="${radians(90)}" effort="9806.65" velocity="${radians(115)}" />
+    <limit lower="${radians(-86)}" upper="${radians(90)}" effort="9806.65" velocity="${radians(115)}" />
   </joint>
   <joint name="${prefix}joint_4" type="revolute">
     <parent link="${prefix}link_3" />


### PR DESCRIPTION
For a time during the DX200 era, the manuals shared the U (link_3) axis limits as the limits relative to the ground, which made the stated U (link_3) axis limit really a compound of the the U axis and the L axis (link_3 and link_2). It was a temporary thing, but some URDFs are incorrect because they just copied the values from the manual. 